### PR TITLE
Single draw call for each pass

### DIFF
--- a/src/allocator/allocator.c
+++ b/src/allocator/allocator.c
@@ -63,7 +63,7 @@ static bool i32_is_aligned(i32 bytes)
 
 static bool valid_type(i32 type)
 {
-    return (u32)type < (u32)EAlloc_Count;
+    return (u32)type < (u32)EAlloc_COUNT;
 }
 
 static bool valid_tid(i32 tid)

--- a/src/common/macro.h
+++ b/src/common/macro.h
@@ -97,8 +97,6 @@
 #define PIM_FWD_DECL(name)          typedef struct name name
 #define PIM_DECL_HANDLE(name)       typedef struct name##_T* name
 
-PIM_C_BEGIN
-
 typedef signed char                 i8;
 typedef signed short                i16;
 typedef signed int                  i32;
@@ -130,10 +128,11 @@ typedef u64                         usize;
 
 typedef enum
 {
-	EAlloc_Perm = 0,
-	EAlloc_Texture,
+    EAlloc_Perm = 0,
+    EAlloc_Texture,
     EAlloc_Temp,
-    EAlloc_Count
+
+    EAlloc_COUNT
 } EAlloc;
 
 #define kMaxThreads                 256
@@ -152,5 +151,3 @@ typedef enum
 #endif // _DEBUG
 
 #define VKR_DEBUG_MESSENGER_ON      (VKR_KHRONOS_LAYER_ON || VKR_ASSIST_LAYER_ON)
-
-PIM_C_END

--- a/src/common/macro.h
+++ b/src/common/macro.h
@@ -108,6 +108,15 @@ typedef unsigned int                u32;
 typedef unsigned long long          u64;
 typedef u64                         usize;
 
+SASSERT(sizeof(i8) == 1);
+SASSERT(sizeof(u8) == 1);
+SASSERT(sizeof(i16) == 2);
+SASSERT(sizeof(u16) == 2);
+SASSERT(sizeof(i32) == 4);
+SASSERT(sizeof(u32) == 4);
+SASSERT(sizeof(i64) == 8);
+SASSERT(sizeof(u64) == 8);
+
 #ifndef NULL
     #ifdef __cplusplus
         #define NULL                0

--- a/src/common/random.h
+++ b/src/common/random.h
@@ -14,7 +14,7 @@ void prng_set(prng_t rng);
 #pragma warning(disable : 4146)
 #pragma warning(disable : 4244)
 
-pim_inline u32 prng_u32(prng_t* rng)
+pim_inline u32 prng_u32(prng_t *const pim_noalias rng)
 {
     u64 oldstate = rng->state;
     rng->state = oldstate * 6364136223846793005ull + 1ull;
@@ -25,17 +25,17 @@ pim_inline u32 prng_u32(prng_t* rng)
 
 #pragma warning(pop)
 
-pim_inline bool prng_bool(prng_t* rng)
+pim_inline bool prng_bool(prng_t *const pim_noalias rng)
 {
     return prng_u32(rng) & 1u;
 }
 
-pim_inline i32 prng_i32(prng_t* rng)
+pim_inline i32 prng_i32(prng_t *const pim_noalias rng)
 {
     return (i32)(0x7fffffff & prng_u32(rng));
 }
 
-pim_inline u64 prng_u64(prng_t* rng)
+pim_inline u64 prng_u64(prng_t *const pim_noalias rng)
 {
     u64 y = prng_u32(rng);
     y <<= 32;
@@ -43,7 +43,7 @@ pim_inline u64 prng_u64(prng_t* rng)
     return y;
 }
 
-pim_inline float VEC_CALL prng_f32(prng_t* rng)
+pim_inline float VEC_CALL prng_f32(prng_t *const pim_noalias rng)
 {
     u32 x = prng_u32(rng) & 0xffffff;
     const float kScale = 1.0f / (1 << 24);

--- a/src/containers/queue.c
+++ b/src/containers/queue.c
@@ -18,10 +18,7 @@ void queue_destroy(queue_t* q)
 {
     ASSERT(q);
     pim_free(q->ptr);
-    q->ptr = NULL;
-    q->width = 0;
-    q->iRead = 0;
-    q->iWrite = 0;
+    memset(q, 0, sizeof(*q));
 }
 
 u32 queue_size(const queue_t* q)

--- a/src/io/fd.c
+++ b/src/io/fd.c
@@ -8,28 +8,19 @@
 
 static i32 NotNeg(i32 x)
 {
-    if (x < 0)
-    {
-        ASSERT(false);
-    }
+    ASSERT(x >= 0);
     return x;
 }
 
 static void* NotNull(void* x)
 {
-    if (!x)
-    {
-        ASSERT(false);
-    }
+    ASSERT(x != NULL);
     return x;
 }
 
 static i32 IsZero(i32 x)
 {
-    if (x)
-    {
-        ASSERT(false);
-    }
+    ASSERT(x == 0);
     return x;
 }
 
@@ -62,15 +53,16 @@ fd_t fd_open(const char* filename, i32 writable)
     return (fd_t) { _open(filename, flags, mode) };
 }
 
-void fd_close(fd_t* fd)
+bool fd_close(fd_t* fd)
 {
     ASSERT(fd);
     i32 handle = fd->handle;
     fd->handle = -1;
     if (handle > 2)
     {
-        IsZero(_close(handle));
+        return IsZero(_close(handle)) == 0;
     }
+    return false;
 }
 
 i32 fd_read(fd_t fd, void* dst, i32 size)
@@ -119,11 +111,11 @@ i32 fd_printf(fd_t fd, const char* fmt, ...)
     return b;
 }
 
-i32 fd_seek(fd_t fd, i32 offset)
+bool fd_seek(fd_t fd, i32 offset)
 {
     ASSERT(fd.handle >= 0);
     ASSERT(offset >= 0);
-    return NotNeg((i32)_lseek(fd.handle, offset, 0));
+    return NotNeg((i32)_lseek(fd.handle, offset, 0)) >= 0;
 }
 
 i32 fd_tell(fd_t fd)
@@ -132,21 +124,22 @@ i32 fd_tell(fd_t fd)
     return NotNeg((i32)_tell(fd.handle));
 }
 
-void fd_pipe(fd_t* fd0, fd_t* fd1, i32 bufferSize)
+bool fd_pipe(fd_t* fd0, fd_t* fd1, i32 bufferSize)
 {
     ASSERT(fd0);
     ASSERT(fd1);
     ASSERT(bufferSize >= 0);
     i32 handles[2] = { -1, -1 };
-    IsZero(_pipe(handles, (u32)bufferSize, _O_BINARY));
+    bool success = IsZero(_pipe(handles, (u32)bufferSize, _O_BINARY)) == 0;
     fd0->handle = handles[0];
     fd1->handle = handles[1];
+    return success;
 }
 
-void fd_stat(fd_t fd, fd_status_t* status)
+bool fd_stat(fd_t fd, fd_status_t* status)
 {
     ASSERT(fd.handle >= 0);
     ASSERT(status);
     memset(status, 0, sizeof(fd_status_t));
-    IsZero(_fstat64(fd.handle, (struct _stat64*)status));
+    return IsZero(_fstat64(fd.handle, (struct _stat64*)status)) == 0;
 }

--- a/src/io/fd.h
+++ b/src/io/fd.h
@@ -5,7 +5,7 @@
 PIM_C_BEGIN
 
 typedef struct fd_s { i32 handle; } fd_t;
-pim_inline i32 fd_isopen(fd_t fd) { return fd.handle >= 0; }
+pim_inline bool fd_isopen(fd_t fd) { return fd.handle >= 0; }
 
 static const fd_t fd_stdin = { 0 };
 static const fd_t fd_stdout = { 1 };
@@ -39,7 +39,7 @@ typedef struct fd_status_s
 
 fd_t fd_create(const char* filename);
 fd_t fd_open(const char* filename, i32 writable);
-void fd_close(fd_t* hdl);
+bool fd_close(fd_t* hdl);
 
 i32 fd_read(fd_t hdl, void* dst, i32 size);
 i32 fd_write(fd_t hdl, const void* src, i32 size);
@@ -47,11 +47,11 @@ i32 fd_write(fd_t hdl, const void* src, i32 size);
 i32 fd_puts(fd_t hdl, const char* str);
 i32 fd_printf(fd_t hdl, const char* fmt, ...);
 
-i32 fd_seek(fd_t hdl, i32 offset);
+bool fd_seek(fd_t hdl, i32 offset);
 i32 fd_tell(fd_t hdl);
 
-void fd_pipe(fd_t* p0, fd_t* p1, i32 bufferSize);
-void fd_stat(fd_t hdl, fd_status_t* status);
+bool fd_pipe(fd_t* p0, fd_t* p1, i32 bufferSize);
+bool fd_stat(fd_t hdl, fd_status_t* status);
 
 pim_inline i64 fd_size(fd_t fd)
 {

--- a/src/io/fstr.c
+++ b/src/io/fstr.c
@@ -37,22 +37,23 @@ fstr_t fstr_open(const char* filename, const char* mode)
     return (fstr_t) { ptr };
 }
 
-void fstr_close(fstr_t* stream)
+bool fstr_close(fstr_t* stream)
 {
     ASSERT(stream);
     FILE* file = stream->handle;
     stream->handle = NULL;
     if (file)
     {
-        IsZero(fclose(file));
+        return IsZero(fclose(file)) == 0;
     }
+    return false;
 }
 
-void fstr_flush(fstr_t stream)
+bool fstr_flush(fstr_t stream)
 {
     FILE* file = stream.handle;
     ASSERT(file);
-    IsZero(fflush(file));
+    return IsZero(fflush(file)) == 0;
 }
 
 i32 fstr_read(fstr_t stream, void* dst, i32 size)
@@ -83,13 +84,13 @@ i32 fstr_write(fstr_t stream, const void* src, i32 size)
     return (ct == 1) ? size : 0;
 }
 
-void fstr_gets(fstr_t stream, char* dst, i32 size)
+bool fstr_gets(fstr_t stream, char* dst, i32 size)
 {
     FILE* file = stream.handle;
     ASSERT(file);
     ASSERT(dst);
     ASSERT(size > 0);
-    NotNull(fgets(dst, size - 1, file));
+    return NotNull(fgets(dst, size - 1, file)) != NULL;
 }
 
 i32 fstr_puts(fstr_t stream, const char* src)
@@ -122,12 +123,12 @@ fstr_t fd_to_fstr(fd_t* pFD, const char* mode)
     return (fstr_t) { NotNull(ptr) };
 }
 
-void fstr_seek(fstr_t stream, i32 offset)
+bool fstr_seek(fstr_t stream, i32 offset)
 {
     FILE* file = stream.handle;
     ASSERT(file);
     ASSERT(offset >= 0);
-    NotNeg(fseek(file, offset, SEEK_SET));
+    return NotNeg(fseek(file, offset, SEEK_SET)) >= 0;
 }
 
 i32 fstr_tell(fstr_t stream)
@@ -145,13 +146,14 @@ fstr_t fstr_popen(const char* cmd, const char* mode)
     return (fstr_t) { NotNull(file) };
 }
 
-void fstr_pclose(fstr_t* pStream)
+bool fstr_pclose(fstr_t* pStream)
 {
     ASSERT(pStream);
     FILE* file = pStream->handle;
     pStream->handle = NULL;
     if (file)
     {
-        IsZero(_pclose(file));
+        return IsZero(_pclose(file)) == 0;
     }
+    return false;
 }

--- a/src/io/fstr.h
+++ b/src/io/fstr.h
@@ -10,25 +10,25 @@ typedef struct fstr_s { void* handle; } fstr_t;
 pim_inline i32 fstr_isopen(fstr_t fstr) { return fstr.handle != NULL; }
 
 fstr_t fstr_open(const char* filename, const char* mode);
-void fstr_close(fstr_t* stream);
-void fstr_flush(fstr_t stream);
+bool fstr_close(fstr_t* stream);
+bool fstr_flush(fstr_t stream);
 i32 fstr_read(fstr_t stream, void* dst, i32 size);
 i32 fstr_write(fstr_t stream, const void* src, i32 size);
-void fstr_gets(fstr_t stream, char* dst, i32 size);
+bool fstr_gets(fstr_t stream, char* dst, i32 size);
 i32 fstr_puts(fstr_t stream, const char* src);
 
 fd_t fstr_to_fd(fstr_t stream);
 fstr_t fd_to_fstr(fd_t* hdl, const char* mode);
 
-void fstr_seek(fstr_t stream, i32 offset);
+bool fstr_seek(fstr_t stream, i32 offset);
 i32 fstr_tell(fstr_t stream);
 
 fstr_t fstr_popen(const char* cmd, const char* mode);
-void fstr_pclose(fstr_t* stream);
+bool fstr_pclose(fstr_t* stream);
 
-pim_inline void fstr_stat(fstr_t stream, fd_status_t* status)
+pim_inline bool fstr_stat(fstr_t stream, fd_status_t* status)
 {
-    fd_stat(fstr_to_fd(stream), status);
+    return fd_stat(fstr_to_fd(stream), status);
 }
 
 pim_inline i64 fstr_size(fstr_t stream)

--- a/src/math/float4_funcs.h
+++ b/src/math/float4_funcs.h
@@ -1027,7 +1027,7 @@ pim_inline float2 VEC_CALL f4_f2(float4 v)
     return (float2) { v.x, v.y };
 }
 
-pim_inline float4 VEC_CALL f4_rand(prng_t* rng)
+pim_inline float4 VEC_CALL f4_rand(prng_t *const pim_noalias rng)
 {
     return f4_v(prng_f32(rng), prng_f32(rng), prng_f32(rng), prng_f32(rng));
 }

--- a/src/rendering/drawable.c
+++ b/src/rendering/drawable.c
@@ -233,8 +233,6 @@ bool drawables_save(crate_t* crate, const drawables_t* src)
         {
             const material_t mat = src->materials[i];
             dmaterial_t dmat = { 0 };
-            dmat.flatAlbedo = mat.flatAlbedo;
-            dmat.flatRome = mat.flatRome;
             dmat.flags = mat.flags;
             dmat.ior = mat.ior;
             texture_save(crate, mat.albedo, &dmat.albedo.id);
@@ -309,8 +307,6 @@ bool drawables_load(crate_t* crate, drawables_t* dst)
                 {
                     const dmaterial_t dmat = dmaterials[i];
                     material_t mat = { 0 };
-                    mat.flatAlbedo = dmat.flatAlbedo;
-                    mat.flatRome = dmat.flatRome;
                     mat.flags = dmat.flags;
                     mat.ior = dmat.ior;
                     texture_load(crate, dmat.albedo.id, &mat.albedo);

--- a/src/rendering/lightmap.h
+++ b/src/rendering/lightmap.h
@@ -26,7 +26,7 @@ typedef struct crate_s crate_t;
 
 typedef struct lightmap_s
 {
-    textureid_t ids[kGiDirections];
+    vkrTextureId slots[kGiDirections];
     float4* pim_noalias probes[kGiDirections];
     float3* pim_noalias position;
     float3* pim_noalias normal;

--- a/src/rendering/lightmap.h
+++ b/src/rendering/lightmap.h
@@ -26,12 +26,12 @@ typedef struct crate_s crate_t;
 
 typedef struct lightmap_s
 {
+    textureid_t ids[kGiDirections];
     float4* pim_noalias probes[kGiDirections];
     float3* pim_noalias position;
     float3* pim_noalias normal;
     float* pim_noalias sampleCounts;
     i32 size;
-    vkrTexture2D vkrtex[kGiDirections];
 } lightmap_t;
 
 typedef struct lmpack_s

--- a/src/rendering/material.h
+++ b/src/rendering/material.h
@@ -22,8 +22,6 @@ typedef u32 matflag_t;
 
 typedef struct material_s
 {
-    float4 flatAlbedo;      // albedo multiplier
-    float4 flatRome;        // rome multiplier
     textureid_t albedo;     // rgba8 srgb (albedo, alpha)
     textureid_t rome;       // rgba8 srgb (roughness, occlusion, metallic, emission)
     textureid_t normal;     // rgba8 (tangent space xyz, packed as unorm)
@@ -36,8 +34,6 @@ typedef struct dmaterial_s
     dtextureid_t albedo;
     dtextureid_t rome;
     dtextureid_t normal;
-    float4 flatAlbedo;
-    float4 flatRome;
     matflag_t flags;
     float ior;
 } dmaterial_t;

--- a/src/rendering/mesh.c
+++ b/src/rendering/mesh.c
@@ -43,10 +43,6 @@ static void FreeMesh(mesh_t* mesh)
     pim_free(mesh->positions);
     pim_free(mesh->normals);
     pim_free(mesh->uvs);
-    if (g_vkr.inst)
-    {
-        vkrMesh_Del(&mesh->vkrmesh);
-    }
     memset(mesh, 0, sizeof(*mesh));
 }
 
@@ -74,19 +70,6 @@ void mesh_sys_shutdown(void)
     table_del(&ms_table);
 }
 
-void mesh_sys_vkfree(void)
-{
-    mesh_t* pim_noalias meshes = ms_table.values;
-    const i32 width = ms_table.width;
-    for (i32 i = 0; i < width; ++i)
-    {
-        if (meshes[i].positions)
-        {
-            vkrMesh_Del(&meshes[i].vkrmesh);
-        }
-    }
-}
-
 bool mesh_new(mesh_t* mesh, guid_t name, meshid_t* idOut)
 {
     ASSERT(mesh);
@@ -100,11 +83,6 @@ bool mesh_new(mesh_t* mesh, guid_t name, meshid_t* idOut)
     genid id = { 0, 0 };
     if (mesh->length > 0)
     {
-        if (g_vkr.inst)
-        {
-            added = vkrMesh_New(&mesh->vkrmesh, mesh->length, mesh->positions, mesh->normals, mesh->uvs, 0, NULL);
-            ASSERT(added);
-        }
         added = table_add(&ms_table, name, mesh, &id);
         ASSERT(added);
     }

--- a/src/rendering/mesh.h
+++ b/src/rendering/mesh.h
@@ -4,7 +4,6 @@
 #include "math/types.h"
 #include "common/guid.h"
 #include "common/dbytes.h"
-#include "rendering/vulkan/vkr.h"
 
 PIM_C_BEGIN
 
@@ -23,11 +22,10 @@ typedef struct dmeshid_s
 
 typedef struct mesh_s
 {
-    float4* positions;
-    float4* normals;
-    float4* uvs;
+    float4* pim_noalias positions;
+    float4* pim_noalias normals;
+    float4* pim_noalias uvs;
     i32 length;
-    vkrMesh vkrmesh;
 } mesh_t;
 
 #define kMeshVersion 5
@@ -41,7 +39,6 @@ typedef struct dmesh_s
 void mesh_sys_init(void);
 void mesh_sys_update(void);
 void mesh_sys_shutdown(void);
-void mesh_sys_vkfree(void);
 void mesh_sys_gui(bool* pEnabled);
 
 bool mesh_new(mesh_t* mesh, guid_t name, meshid_t* idOut);

--- a/src/rendering/model.c
+++ b/src/rendering/model.c
@@ -170,7 +170,6 @@ static i32 FindPreset(const char* name)
 static material_t GenMaterial(const mtexture_t* mtex, const msurface_t* surf)
 {
     material_t material = { 0 };
-    material.flatAlbedo = f4_1;
     material.ior = 1.0f;
 
     float roughness = 0.5f;
@@ -263,17 +262,17 @@ static material_t GenMaterial(const mtexture_t* mtex, const msurface_t* surf)
             emission = 0.5f;
         }
 
+        float4 flatRome = f4_v(roughness, occlusion, metallic, emission);
         texture_unpalette(
             mip0,
             size,
             mtex->name,
             material.flags,
+            flatRome,
             &material.albedo,
             &material.rome,
             &material.normal);
     }
-
-    material.flatRome = f4_v(roughness, occlusion, metallic, emission);
 
     return material;
 }
@@ -737,7 +736,7 @@ void LoadProgs(const mmodel_t* model, bool loadlights)
         }
         else if (ent.type == pr_classname_worldspawn)
         {
-            
+
         }
         else if (ent.type == pr_classname_info_player_start)
         {

--- a/src/rendering/path_tracer.c
+++ b/src/rendering/path_tracer.c
@@ -161,17 +161,17 @@ pim_inline RTCRayHit VEC_CALL RtcIntersect(
     float4 rd,
     float tNear,
     float tFar);
-static RTCScene RtcNewScene(const pt_scene_t* scene);
-static void FlattenDrawables(pt_scene_t* scene);
+static RTCScene RtcNewScene(const pt_scene_t*const pim_noalias scene);
+static void FlattenDrawables(pt_scene_t*const pim_noalias scene);
 static float EmissionPdf(
-    pt_sampler_t* sampler,
-    const pt_scene_t* scene,
+    pt_sampler_t*const pim_noalias sampler,
+    const pt_scene_t*const pim_noalias scene,
     i32 iVert,
     i32 attempts);
 static void CalcEmissionPdfFn(task_t* pbase, i32 begin, i32 end);
-static void SetupEmissives(pt_scene_t* scene);
+static void SetupEmissives(pt_scene_t*const pim_noalias scene);
 static void SetupLightGridFn(task_t* pbase, i32 begin, i32 end);
-static void SetupLightGrid(pt_scene_t* scene);
+static void SetupLightGrid(pt_scene_t*const pim_noalias scene);
 pim_inline float4 VEC_CALL GetVert4(
     const float4* vertices,
     i32 iVert,
@@ -180,84 +180,84 @@ pim_inline float2 VEC_CALL GetVert2(
     const float2* vertices,
     i32 iVert,
     float4 wuv);
-pim_inline float VEC_CALL GetArea(const pt_scene_t* scene, i32 iLight);
+pim_inline float VEC_CALL GetArea(const pt_scene_t*const pim_noalias scene, i32 iLight);
 pim_inline const material_t* VEC_CALL GetMaterial(
-    const pt_scene_t* scene,
+    const pt_scene_t*const pim_noalias scene,
     rayhit_t hit);
 pim_inline float4 VEC_CALL GetSky(
-    const pt_scene_t* scene,
+    const pt_scene_t*const pim_noalias scene,
     float4 ro,
     float4 rd);
 pim_inline surfhit_t VEC_CALL GetSurface(
-    const pt_scene_t* scene,
+    const pt_scene_t*const pim_noalias scene,
     float4 ro,
     float4 rd,
     rayhit_t hit);
 pim_inline rayhit_t VEC_CALL pt_intersect_local(
-    const pt_scene_t* scene,
+    const pt_scene_t*const pim_noalias scene,
     float4 ro,
     float4 rd,
     float tNear,
     float tFar);
 pim_inline float4 VEC_CALL SampleSpecular(
-    pt_sampler_t* sampler,
+    pt_sampler_t*const pim_noalias sampler,
     float4 I,
     float4 N,
     float alpha);
 pim_inline float4 VEC_CALL SampleDiffuse(
-    pt_sampler_t* sampler,
+    pt_sampler_t*const pim_noalias sampler,
     float4 N);
 pim_inline float4 VEC_CALL RefractBrdfEval(
-    pt_sampler_t* sampler,
+    pt_sampler_t*const pim_noalias sampler,
     float4 I,
     const surfhit_t* surf,
     float4 L);
 pim_inline float4 VEC_CALL BrdfEval(
-    pt_sampler_t* sampler,
+    pt_sampler_t*const pim_noalias sampler,
     float4 I,
     const surfhit_t* surf,
     float4 L);
 pim_inline scatter_t VEC_CALL RefractScatter(
-    pt_sampler_t* sampler,
+    pt_sampler_t*const pim_noalias sampler,
     const surfhit_t* surf,
     float4 I);
 pim_inline scatter_t VEC_CALL BrdfScatter(
-    pt_sampler_t* sampler,
+    pt_sampler_t*const pim_noalias sampler,
     const surfhit_t* surf,
     float4 I);
 pim_inline bool VEC_CALL LightSelect(
-    pt_sampler_t* sampler,
-    pt_scene_t* scene,
+    pt_sampler_t*const pim_noalias sampler,
+    pt_scene_t*const pim_noalias scene,
     float4 position,
     i32* iVertOut,
     float* pdfOut);
 pim_inline lightsample_t VEC_CALL LightSample(
-    pt_sampler_t* sampler,
-    pt_scene_t* scene,
+    pt_sampler_t*const pim_noalias sampler,
+    pt_scene_t*const pim_noalias scene,
     float4 ro,
     i32 iLight);
 pim_inline float VEC_CALL LightEvalPdf(
-    pt_sampler_t* sampler,
-    pt_scene_t* scene,
+    pt_sampler_t*const pim_noalias sampler,
+    pt_scene_t*const pim_noalias scene,
     float4 ro,
     float4 rd,
     rayhit_t* hitOut);
 pim_inline float4 VEC_CALL EstimateDirect(
-    pt_sampler_t* sampler,
-    pt_scene_t* scene,
+    pt_sampler_t*const pim_noalias sampler,
+    pt_scene_t*const pim_noalias scene,
     const surfhit_t* surf,
     i32 iLight,
     float selectPdf,
     float4 I);
 pim_inline float4 VEC_CALL SampleLights(
-    pt_sampler_t* sampler,
-    pt_scene_t* scene,
+    pt_sampler_t*const pim_noalias sampler,
+    pt_scene_t*const pim_noalias scene,
     const surfhit_t* surf,
     const rayhit_t* hit,
     float4 I);
 pim_inline bool VEC_CALL EvaluateLight(
-    pt_sampler_t* sampler,
-    pt_scene_t* scene,
+    pt_sampler_t*const pim_noalias sampler,
+    pt_scene_t*const pim_noalias scene,
     float4 P,
     float4* lightOut,
     float4* dirOut);
@@ -273,31 +273,35 @@ pim_inline float4 VEC_CALL Media_Albedo(const media_desc_t* desc, float4 P);
 pim_inline float4 VEC_CALL Media_Normal(const media_desc_t* desc, float4 P);
 pim_inline media_t VEC_CALL Media_Lerp(media_t lhs, media_t rhs, float t);
 pim_inline bool VEC_CALL RussianRoulette(
-    pt_sampler_t* sampler,
+    pt_sampler_t*const pim_noalias sampler,
     float4* pAttenuation);
 pim_inline float VEC_CALL SampleFreePath(float Xi, float rcpU);
 pim_inline float VEC_CALL FreePathPdf(float t, float u);
 pim_inline float4 VEC_CALL CalcTransmittance(
-    pt_sampler_t* sampler,
-    const pt_scene_t* scene,
+    pt_sampler_t*const pim_noalias sampler,
+    const pt_scene_t*const pim_noalias scene,
     float4 ro,
     float4 rd,
     float rayLen);
 pim_inline scatter_t VEC_CALL ScatterRay(
-    pt_sampler_t* sampler,
-    pt_scene_t* scene,
+    pt_sampler_t*const pim_noalias sampler,
+    pt_scene_t*const pim_noalias scene,
     float4 ro,
     float4 rd,
     float rayLen);
 static void TraceFn(void* pbase, i32 begin, i32 end);
 static void RayGenFn(void* pBase, i32 begin, i32 end);
-pim_inline float VEC_CALL Sample1D(pt_sampler_t* sampler);
-pim_inline float2 VEC_CALL Sample2D(pt_sampler_t* sampler);
-pim_inline bool VEC_CALL SampleBool(pt_sampler_t* sampler);
+pim_inline float VEC_CALL Sample1D(pt_sampler_t*const pim_noalias sampler);
+pim_inline float2 VEC_CALL Sample2D(pt_sampler_t*const pim_noalias sampler);
+pim_inline bool VEC_CALL SampleBool(pt_sampler_t*const pim_noalias sampler);
 pim_inline pt_sampler_t VEC_CALL GetSampler(void);
 pim_inline void VEC_CALL SetSampler(pt_sampler_t sampler);
-pim_inline void VEC_CALL LightOnHit(pt_sampler_t* sampler, pt_scene_t* scene, float4 ro, i32 iVert);
-static void UpdateDists(pt_scene_t* scene);
+pim_inline void VEC_CALL LightOnHit(
+    pt_sampler_t*const pim_noalias sampler,
+    pt_scene_t*const pim_noalias scene,
+    float4 ro,
+    i32 iVert);
+static void UpdateDists(pt_scene_t*const pim_noalias scene);
 
 // ----------------------------------------------------------------------------
 
@@ -315,7 +319,7 @@ static cvar_t cv_pt_dist_alpha =
 {
     .type = cvart_float,
     .name = "pt_dist_alpha",
-    .value = "0.5",
+    .value = "1",
     .minFloat = 0.0f,
     .maxFloat = 1.0f,
     .desc = "path tracer light distribution update amount",
@@ -419,8 +423,8 @@ void pt_sys_shutdown(void)
 
 pt_sampler_t VEC_CALL pt_sampler_get(void) { return GetSampler(); }
 void VEC_CALL pt_sampler_set(pt_sampler_t sampler) { SetSampler(sampler); }
-float2 VEC_CALL pt_sample_2d(pt_sampler_t* sampler) { return Sample2D(sampler); }
-float VEC_CALL pt_sample_1d(pt_sampler_t* sampler) { return Sample1D(sampler); }
+float2 VEC_CALL pt_sample_2d(pt_sampler_t*const pim_noalias sampler) { return Sample2D(sampler); }
+float VEC_CALL pt_sample_1d(pt_sampler_t*const pim_noalias sampler) { return Sample1D(sampler); }
 
 pim_inline RTCRay VEC_CALL RtcNewRay(float4 ro, float4 rd, float tNear, float tFar)
 {
@@ -563,7 +567,7 @@ static bool RtcPointQueryFn(RTCPointQueryFunctionArguments* args)
     return false;
 }
 
-pim_inline PointQueryUserData VEC_CALL RtcPointQuery(const pt_scene_t* scene, float4 pt)
+pim_inline PointQueryUserData VEC_CALL RtcPointQuery(const pt_scene_t*const pim_noalias scene, float4 pt)
 {
     PointQueryUserData usr = { 0 };
     usr.positions = scene->positions;
@@ -582,7 +586,7 @@ pim_inline PointQueryUserData VEC_CALL RtcPointQuery(const pt_scene_t* scene, fl
     return usr;
 }
 
-static RTCScene RtcNewScene(const pt_scene_t* scene)
+static RTCScene RtcNewScene(const pt_scene_t*const pim_noalias scene)
 {
     RTCScene rtcScene = rtc.NewScene(ms_device);
     ASSERT(rtcScene);
@@ -655,7 +659,7 @@ static RTCScene RtcNewScene(const pt_scene_t* scene)
     return rtcScene;
 }
 
-static void FlattenDrawables(pt_scene_t* scene)
+static void FlattenDrawables(pt_scene_t*const pim_noalias scene)
 {
     const drawables_t* drawTable = drawables_get();
     const i32 drawCount = drawTable->count;
@@ -742,8 +746,8 @@ static void FlattenDrawables(pt_scene_t* scene)
 }
 
 static float EmissionPdf(
-    pt_sampler_t* sampler,
-    const pt_scene_t* scene,
+    pt_sampler_t*const pim_noalias sampler,
+    const pt_scene_t*const pim_noalias scene,
     i32 iVert,
     i32 attempts)
 {
@@ -799,7 +803,7 @@ typedef struct task_CalcEmissionPdf
 static void CalcEmissionPdfFn(task_t* pbase, i32 begin, i32 end)
 {
     task_CalcEmissionPdf* task = (task_CalcEmissionPdf*)pbase;
-    const pt_scene_t* scene = task->scene;
+    const pt_scene_t*const pim_noalias scene = task->scene;
     const i32 attempts = task->attempts;
     float* pim_noalias pdfs = task->pdfs;
 
@@ -811,7 +815,7 @@ static void CalcEmissionPdfFn(task_t* pbase, i32 begin, i32 end)
     pt_sampler_set(sampler);
 }
 
-static void SetupEmissives(pt_scene_t* scene)
+static void SetupEmissives(pt_scene_t*const pim_noalias scene)
 {
     const i32 vertCount = scene->vertCount;
     const i32 triCount = vertCount / 3;
@@ -865,7 +869,7 @@ static void SetupLightGridFn(task_t* pbase, i32 begin, i32 end)
 {
     task_SetupLightGrid* task = (task_SetupLightGrid*)pbase;
 
-    pt_scene_t* scene = task->scene;
+    pt_scene_t*const pim_noalias scene = task->scene;
 
     const grid_t grid = scene->lightGrid;
     dist1d_t *const pim_noalias dists = scene->lightDists;
@@ -966,7 +970,7 @@ static void SetupLightGridFn(task_t* pbase, i32 begin, i32 end)
     SetSampler(sampler);
 }
 
-static void SetupLightGrid(pt_scene_t* scene)
+static void SetupLightGrid(pt_scene_t*const pim_noalias scene)
 {
     if (scene->vertCount > 0)
     {
@@ -985,7 +989,7 @@ static void SetupLightGrid(pt_scene_t* scene)
     }
 }
 
-void pt_scene_update(pt_scene_t* scene)
+void pt_scene_update(pt_scene_t*const pim_noalias scene)
 {
     guid_t skyname = guid_str("sky");
     cubemaps_t* maps = Cubemaps_Get();
@@ -1009,7 +1013,7 @@ pt_scene_t* pt_scene_new(void)
         return NULL;
     }
 
-    pt_scene_t* scene = perm_calloc(sizeof(*scene));
+    pt_scene_t*const pim_noalias scene = perm_calloc(sizeof(*scene));
     pt_scene_update(scene);
 
     FlattenDrawables(scene);
@@ -1021,7 +1025,7 @@ pt_scene_t* pt_scene_new(void)
     return scene;
 }
 
-void pt_scene_del(pt_scene_t* scene)
+void pt_scene_del(pt_scene_t*const pim_noalias scene)
 {
     if (scene)
     {
@@ -1058,7 +1062,7 @@ void pt_scene_del(pt_scene_t* scene)
     }
 }
 
-void pt_scene_gui(pt_scene_t* scene)
+void pt_scene_gui(pt_scene_t*const pim_noalias scene)
 {
     if (scene && igCollapsingHeader1("pt scene"))
     {
@@ -1073,7 +1077,7 @@ void pt_scene_gui(pt_scene_t* scene)
 
 void pt_trace_new(
     pt_trace_t* trace,
-    pt_scene_t* scene,
+    pt_scene_t*const pim_noalias scene,
     int2 imageSize)
 {
     ASSERT(trace);
@@ -1167,14 +1171,14 @@ pim_inline float2 VEC_CALL GetVert2(
         wuv);
 }
 
-pim_inline float VEC_CALL GetArea(const pt_scene_t* scene, i32 iVert)
+pim_inline float VEC_CALL GetArea(const pt_scene_t*const pim_noalias scene, i32 iVert)
 {
     const float4* pim_noalias positions = scene->positions;
     return TriArea3D(positions[iVert + 0], positions[iVert + 1], positions[iVert + 2]);
 }
 
 pim_inline const material_t* VEC_CALL GetMaterial(
-    const pt_scene_t* scene,
+    const pt_scene_t*const pim_noalias scene,
     rayhit_t hit)
 {
     i32 iVert = hit.index;
@@ -1187,7 +1191,7 @@ pim_inline const material_t* VEC_CALL GetMaterial(
 }
 
 pim_inline float4 VEC_CALL GetSky(
-    const pt_scene_t* scene,
+    const pt_scene_t*const pim_noalias scene,
     float4 ro,
     float4 rd)
 {
@@ -1199,7 +1203,7 @@ pim_inline float4 VEC_CALL GetSky(
 }
 
 pim_inline surfhit_t VEC_CALL GetSurface(
-    const pt_scene_t* scene,
+    const pt_scene_t*const pim_noalias scene,
     float4 ro,
     float4 rd,
     rayhit_t hit)
@@ -1229,8 +1233,7 @@ pim_inline surfhit_t VEC_CALL GetSurface(
         texture_t const *const tex = texture_get(mat->albedo);
         if (tex)
         {
-            float4 sample = UvBilinearWrap_c32(tex->texels, tex->size, uv);
-            surf.albedo = f4_mul(surf.albedo, sample);
+            surf.albedo = UvBilinearWrap_c32(tex->texels, tex->size, uv);
         }
     }
 
@@ -1239,8 +1242,7 @@ pim_inline surfhit_t VEC_CALL GetSurface(
         texture_t const *const tex = texture_get(mat->rome);
         if (tex)
         {
-            float4 sample = UvBilinearWrap_c32(tex->texels, tex->size, uv);
-            rome = f4_mul(rome, sample);
+            rome = UvBilinearWrap_c32(tex->texels, tex->size, uv);
         }
     }
     surf.emission = UnpackEmission(surf.albedo, rome.w);
@@ -1257,7 +1259,7 @@ pim_inline surfhit_t VEC_CALL GetSurface(
 }
 
 pim_inline rayhit_t VEC_CALL pt_intersect_local(
-    const pt_scene_t* scene,
+    const pt_scene_t*const pim_noalias scene,
     float4 ro,
     float4 rd,
     float tNear,
@@ -1300,7 +1302,7 @@ pim_inline rayhit_t VEC_CALL pt_intersect_local(
 }
 
 rayhit_t VEC_CALL pt_intersect(
-    pt_scene_t* scene,
+    pt_scene_t*const pim_noalias scene,
     float4 ro,
     float4 rd,
     float tNear,
@@ -1310,7 +1312,7 @@ rayhit_t VEC_CALL pt_intersect(
 }
 
 pim_inline float4 VEC_CALL SampleSpecular(
-    pt_sampler_t* sampler,
+    pt_sampler_t*const pim_noalias sampler,
     float4 I,
     float4 N,
     float alpha)
@@ -1326,7 +1328,7 @@ pim_inline float4 VEC_CALL SampleSpecular(
 }
 
 pim_inline float4 VEC_CALL SampleDiffuse(
-    pt_sampler_t* sampler,
+    pt_sampler_t*const pim_noalias sampler,
     float4 N)
 {
     float2 Xi = Sample2D(sampler);
@@ -1346,7 +1348,7 @@ pim_inline float VEC_CALL Schlick(float cosTheta, float k)
 }
 
 pim_inline float4 VEC_CALL RefractBrdfEval(
-    pt_sampler_t* sampler,
+    pt_sampler_t*const pim_noalias sampler,
     float4 I,
     const surfhit_t* surf,
     float4 L)
@@ -1356,7 +1358,7 @@ pim_inline float4 VEC_CALL RefractBrdfEval(
 
 // returns attenuation value for the given interaction
 pim_inline float4 VEC_CALL BrdfEval(
-    pt_sampler_t* sampler,
+    pt_sampler_t*const pim_noalias sampler,
     float4 I,
     const surfhit_t* surf,
     float4 L)
@@ -1416,7 +1418,7 @@ pim_inline float4 VEC_CALL BrdfEval(
 }
 
 pim_inline scatter_t VEC_CALL RefractScatter(
-    pt_sampler_t* sampler,
+    pt_sampler_t*const pim_noalias sampler,
     const surfhit_t* surf,
     float4 I)
 {
@@ -1476,7 +1478,7 @@ pim_inline scatter_t VEC_CALL RefractScatter(
 }
 
 pim_inline scatter_t VEC_CALL BrdfScatter(
-    pt_sampler_t* sampler,
+    pt_sampler_t*const pim_noalias sampler,
     const surfhit_t* surf,
     float4 I)
 {
@@ -1556,8 +1558,8 @@ pim_inline scatter_t VEC_CALL BrdfScatter(
 }
 
 pim_inline void VEC_CALL LightOnHit(
-    pt_sampler_t* sampler,
-    pt_scene_t* scene,
+    pt_sampler_t*const pim_noalias sampler,
+    pt_scene_t*const pim_noalias scene,
     float4 ro,
     i32 iVert)
 {
@@ -1574,8 +1576,8 @@ pim_inline void VEC_CALL LightOnHit(
 }
 
 pim_inline bool VEC_CALL LightSelect(
-    pt_sampler_t* sampler,
-    pt_scene_t* scene,
+    pt_sampler_t*const pim_noalias sampler,
+    pt_scene_t*const pim_noalias scene,
     float4 position,
     i32* iVertOut,
     float* pdfOut)
@@ -1605,8 +1607,8 @@ pim_inline bool VEC_CALL LightSelect(
 }
 
 pim_inline lightsample_t VEC_CALL LightSample(
-    pt_sampler_t* sampler,
-    pt_scene_t* scene,
+    pt_sampler_t*const pim_noalias sampler,
+    pt_scene_t*const pim_noalias scene,
     float4 ro,
     i32 iLight)
 {
@@ -1653,8 +1655,8 @@ pim_inline lightsample_t VEC_CALL LightSample(
 }
 
 pim_inline float VEC_CALL LightEvalPdf(
-    pt_sampler_t* sampler,
-    pt_scene_t* scene,
+    pt_sampler_t*const pim_noalias sampler,
+    pt_scene_t*const pim_noalias scene,
     float4 ro,
     float4 rd,
     rayhit_t* hitOut)
@@ -1680,8 +1682,8 @@ pim_inline float VEC_CALL LightEvalPdf(
 }
 
 pim_inline float4 VEC_CALL EstimateDirect(
-    pt_sampler_t* sampler,
-    pt_scene_t* scene,
+    pt_sampler_t*const pim_noalias sampler,
+    pt_scene_t*const pim_noalias scene,
     const surfhit_t* surf,
     i32 iLight,
     float selectPdf,
@@ -1739,8 +1741,8 @@ pim_inline float4 VEC_CALL EstimateDirect(
 }
 
 pim_inline float4 VEC_CALL SampleLights(
-    pt_sampler_t* sampler,
-    pt_scene_t* scene,
+    pt_sampler_t*const pim_noalias sampler,
+    pt_scene_t*const pim_noalias scene,
     const surfhit_t* surf,
     const rayhit_t* hit,
     float4 I)
@@ -1760,8 +1762,8 @@ pim_inline float4 VEC_CALL SampleLights(
 }
 
 pim_inline bool VEC_CALL EvaluateLight(
-    pt_sampler_t* sampler,
-    pt_scene_t* scene,
+    pt_sampler_t*const pim_noalias sampler,
+    pt_scene_t*const pim_noalias scene,
     float4 P,
     float4* lightOut,
     float4* dirOut)
@@ -2091,7 +2093,7 @@ pim_inline float VEC_CALL CalcPhase(
 }
 
 pim_inline bool VEC_CALL RussianRoulette(
-    pt_sampler_t* sampler,
+    pt_sampler_t*const pim_noalias sampler,
     float4* pAttenuation)
 {
     float4 att = *pAttenuation;
@@ -2110,8 +2112,8 @@ pim_inline bool VEC_CALL RussianRoulette(
 }
 
 pim_inline float4 VEC_CALL CalcTransmittance(
-    pt_sampler_t* sampler,
-    const pt_scene_t* scene,
+    pt_sampler_t*const pim_noalias sampler,
+    const pt_scene_t*const pim_noalias scene,
     float4 ro,
     float4 rd,
     float d)
@@ -2164,7 +2166,7 @@ pim_inline float4 VEC_CALL CalcTransmittance(
 }
 
 pim_inline float4 VEC_CALL SamplePhaseDir(
-    pt_sampler_t* sampler,
+    pt_sampler_t*const pim_noalias sampler,
     const media_desc_t* desc,
     float4 rd)
 {
@@ -2188,8 +2190,8 @@ pim_inline float4 VEC_CALL SamplePhaseDir(
 }
 
 pim_inline scatter_t VEC_CALL ScatterRay(
-    pt_sampler_t* sampler,
-    pt_scene_t* scene,
+    pt_sampler_t*const pim_noalias sampler,
+    pt_scene_t*const pim_noalias scene,
     float4 ro,
     float4 rd,
     float rayLen)
@@ -2251,8 +2253,8 @@ pim_inline scatter_t VEC_CALL ScatterRay(
 }
 
 pt_result_t VEC_CALL pt_trace_ray(
-    pt_sampler_t* sampler,
-    pt_scene_t* scene,
+    pt_sampler_t*const pim_noalias sampler,
+    pt_scene_t*const pim_noalias scene,
     float4 ro,
     float4 rd)
 {
@@ -2347,7 +2349,7 @@ pt_result_t VEC_CALL pt_trace_ray(
 }
 
 pim_inline float2 VEC_CALL SampleUv(
-    pt_sampler_t* sampler,
+    pt_sampler_t*const pim_noalias sampler,
     const dist1d_t* dist)
 {
     float2 Xi = Sample2D(sampler);
@@ -2364,7 +2366,7 @@ pim_inline float2 VEC_CALL SampleUv(
 }
 
 pim_inline ray_t VEC_CALL CalculateDof(
-    pt_sampler_t* sampler,
+    pt_sampler_t*const pim_noalias sampler,
     const dofinfo_t* dof,
     float4 right,
     float4 up,
@@ -2405,9 +2407,9 @@ typedef struct TaskUpdateDists
 
 static void UpdateDistsFn(void* pbase, i32 begin, i32 end)
 {
-    TaskUpdateDists* task = pbase;
-    pt_scene_t* scene = task->scene;
-    dist1d_t* dists = scene->lightDists;
+    TaskUpdateDists*const pim_noalias task = pbase;
+    pt_scene_t*const pim_noalias scene = task->scene;
+    dist1d_t*const pim_noalias dists = scene->lightDists;
     float alpha = task->alpha;
     u32 minSamples = task->minSamples;
     for (i32 i = begin; i < end; ++i)
@@ -2416,9 +2418,9 @@ static void UpdateDistsFn(void* pbase, i32 begin, i32 end)
     }
 }
 
-static void UpdateDists(pt_scene_t* scene)
+static void UpdateDists(pt_scene_t*const pim_noalias scene)
 {
-    TaskUpdateDists* task = tmp_calloc(sizeof(*task));
+    TaskUpdateDists*const pim_noalias task = tmp_calloc(sizeof(*task));
     task->scene = scene;
     task->alpha = cvar_get_float(&cv_pt_dist_alpha);
     task->minSamples = cvar_get_int(&cv_pt_dist_samples);
@@ -2435,15 +2437,15 @@ typedef struct trace_task_s
 
 static void TraceFn(void* pbase, i32 begin, i32 end)
 {
-    trace_task_t* task = pbase;
+    trace_task_t*const pim_noalias task = pbase;
 
-    pt_trace_t* trace = task->trace;
+    pt_trace_t*const pim_noalias trace = task->trace;
     const camera_t camera = task->camera;
 
-    pt_scene_t* scene = trace->scene;
-    float3* pim_noalias color = trace->color;
-    float3* pim_noalias albedo = trace->albedo;
-    float3* pim_noalias normal = trace->normal;
+    pt_scene_t*const pim_noalias scene = trace->scene;
+    float3*const pim_noalias color = trace->color;
+    float3*const pim_noalias albedo = trace->albedo;
+    float3*const pim_noalias normal = trace->normal;
 
     const int2 size = trace->imageSize;
     const float2 rcpSize = f2_rcp(i2_f2(size));
@@ -2493,7 +2495,7 @@ void pt_trace(pt_trace_t* desc, const camera_t* camera)
 
     pt_scene_update(desc->scene);
 
-    trace_task_t* task = tmp_calloc(sizeof(*task));
+    trace_task_t*const pim_noalias task = tmp_calloc(sizeof(*task));
     task->trace = desc;
     task->camera = *camera;
 
@@ -2514,12 +2516,12 @@ typedef struct pt_raygen_s
 
 static void RayGenFn(void* pBase, i32 begin, i32 end)
 {
-    pt_raygen_t* task = pBase;
-    pt_scene_t* scene = task->scene;
+    pt_raygen_t*const pim_noalias task = pBase;
+    pt_scene_t*const pim_noalias scene = task->scene;
     const float4 ro = task->origin;
 
-    float4* pim_noalias colors = task->colors;
-    float4* pim_noalias directions = task->directions;
+    float4*const pim_noalias colors = task->colors;
+    float4*const pim_noalias directions = task->directions;
 
     pt_sampler_t sampler = GetSampler();
     for (i32 i = begin; i < end; ++i)
@@ -2535,7 +2537,7 @@ static void RayGenFn(void* pBase, i32 begin, i32 end)
 
 ProfileMark(pm_raygen, pt_raygen)
 pt_results_t pt_raygen(
-    pt_scene_t* scene,
+    pt_scene_t*const pim_noalias scene,
     float4 origin,
     i32 count)
 {
@@ -2546,7 +2548,7 @@ pt_results_t pt_raygen(
 
     pt_scene_update(scene);
 
-    pt_raygen_t* task = tmp_calloc(sizeof(*task));
+    pt_raygen_t*const pim_noalias task = tmp_calloc(sizeof(*task));
     task->scene = scene;
     task->origin = origin;
     task->colors = tmp_malloc(sizeof(task->colors[0]) * count);
@@ -2564,17 +2566,17 @@ pt_results_t pt_raygen(
     return results;
 }
 
-pim_inline float VEC_CALL Sample1D(pt_sampler_t* sampler)
+pim_inline float VEC_CALL Sample1D(pt_sampler_t*const pim_noalias sampler)
 {
     return prng_f32(&sampler->rng);
 }
 
-pim_inline float2 VEC_CALL Sample2D(pt_sampler_t* sampler)
+pim_inline float2 VEC_CALL Sample2D(pt_sampler_t*const pim_noalias sampler)
 {
     return f2_rand(&sampler->rng);
 }
 
-pim_inline bool VEC_CALL SampleBool(pt_sampler_t* sampler)
+pim_inline bool VEC_CALL SampleBool(pt_sampler_t*const pim_noalias sampler)
 {
     return Sample1D(sampler) < 0.5f;
 }

--- a/src/rendering/path_tracer.c
+++ b/src/rendering/path_tracer.c
@@ -756,8 +756,6 @@ static float EmissionPdf(
     }
 
     const float kThreshold = 0.01f;
-    float4 rome = mat->flatRome;
-    if (rome.w > kThreshold)
     {
         texture_t const *const romeMap = texture_get(mat->rome);
         if (romeMap)
@@ -776,8 +774,7 @@ static float EmissionPdf(
                 float4 wuv = SampleBaryCoord(Sample2D(sampler));
                 float2 uv = f2_blend(UA, UB, UC, wuv);
                 float sample = UvWrap_c32(texels, texSize, uv).w;
-                float em = sample * rome.w;
-                if (em > kThreshold)
+                if (sample > kThreshold)
                 {
                     ++hits;
                 }
@@ -786,12 +783,8 @@ static float EmissionPdf(
         }
         else
         {
-            return 1.0f;
+            return 0.0f;
         }
-    }
-    else
-    {
-        return 0.0f;
     }
 }
 
@@ -1231,7 +1224,7 @@ pim_inline surfhit_t VEC_CALL GetSurface(
         }
     }
 
-    surf.albedo = mat->flatAlbedo;
+    surf.albedo = f4_1;
     {
         texture_t const *const tex = texture_get(mat->albedo);
         if (tex)
@@ -1241,7 +1234,7 @@ pim_inline surfhit_t VEC_CALL GetSurface(
         }
     }
 
-    float4 rome = mat->flatRome;
+    float4 rome = f4_v(0.5f, 1.0f, 0.0f, 0.0f);
     {
         texture_t const *const tex = texture_get(mat->rome);
         if (tex)

--- a/src/rendering/path_tracer.h
+++ b/src/rendering/path_tracer.h
@@ -74,33 +74,33 @@ void pt_sys_shutdown(void);
 
 pt_sampler_t VEC_CALL pt_sampler_get(void);
 void VEC_CALL pt_sampler_set(pt_sampler_t sampler);
-float2 VEC_CALL pt_sample_2d(pt_sampler_t* sampler);
-float VEC_CALL pt_sample_1d(pt_sampler_t* sampler);
+float2 VEC_CALL pt_sample_2d(pt_sampler_t*const pim_noalias sampler);
+float VEC_CALL pt_sample_1d(pt_sampler_t*const pim_noalias sampler);
 
 pt_scene_t* pt_scene_new(void);
-void pt_scene_update(pt_scene_t* scene);
-void pt_scene_del(pt_scene_t* scene);
-void pt_scene_gui(pt_scene_t* scene);
+void pt_scene_update(pt_scene_t*const pim_noalias scene);
+void pt_scene_del(pt_scene_t*const pim_noalias scene);
+void pt_scene_gui(pt_scene_t*const pim_noalias scene);
 
-void pt_trace_new(pt_trace_t* trace, pt_scene_t* scene, int2 imageSize);
+void pt_trace_new(pt_trace_t* trace, pt_scene_t*const pim_noalias scene, int2 imageSize);
 void pt_trace_del(pt_trace_t* trace);
 void pt_trace_gui(pt_trace_t* trace);
 
 void dofinfo_new(dofinfo_t* dof);
 void dofinfo_gui(dofinfo_t* dof);
 
-rayhit_t VEC_CALL pt_intersect(pt_scene_t* scene, float4 ro, float4 rd, float tNear, float tFar);
+rayhit_t VEC_CALL pt_intersect(pt_scene_t*const pim_noalias scene, float4 ro, float4 rd, float tNear, float tFar);
 
 pt_result_t VEC_CALL pt_trace_ray(
-    pt_sampler_t* sampler,
-    pt_scene_t* scene,
+    pt_sampler_t*const pim_noalias sampler,
+    pt_scene_t*const pim_noalias scene,
     float4 ro,
     float4 rd);
 
 void pt_trace(pt_trace_t* traceDesc, const camera_t* camera);
 
 pt_results_t pt_raygen(
-    pt_scene_t* scene,
+    pt_scene_t*const pim_noalias scene,
     float4 origin,
     i32 count);
 

--- a/src/rendering/r_window.c
+++ b/src/rendering/r_window.c
@@ -14,7 +14,7 @@ static cvar_t cv_fpslimit =
 {
     .type = cvart_int,
     .name = "fps_limit",
-    .value = "125",
+    .value = "240",
     .minInt = 1,
     .maxInt = 1000,
     .desc = "limits fps when above this value"
@@ -89,9 +89,9 @@ static void wait_for_target_fps(void)
 
     const double targetMS = 1000.0 / cv_fpslimit.asInt;
     const double diffMS = targetMS - time_milli(time_now() - ms_lastSwap);
-    if (diffMS >= 1.0)
+    if (diffMS > 1.5)
     {
-        intrin_sleep((u32)diffMS);
+        intrin_sleep((u32)(diffMS - 0.5));
     }
 
     ms_lastSwap = time_now();

--- a/src/rendering/render_system.c
+++ b/src/rendering/render_system.c
@@ -720,11 +720,11 @@ void render_sys_init(void)
     cmd_reg("pt_stddev", CmdPtStdDev);
     cmd_reg("loadtest", CmdLoadTest);
 
-    texture_sys_init();
-    mesh_sys_init();
     vkr_init();
     g_vkr.exposurePass.params = ms_exposure;
 
+    texture_sys_init();
+    mesh_sys_init();
     pt_sys_init();
     EnsureFramebuf();
 

--- a/src/rendering/render_system.c
+++ b/src/rendering/render_system.c
@@ -720,11 +720,11 @@ void render_sys_init(void)
     cmd_reg("pt_stddev", CmdPtStdDev);
     cmd_reg("loadtest", CmdLoadTest);
 
+    texture_sys_init();
+    mesh_sys_init();
     vkr_init();
     g_vkr.exposurePass.params = ms_exposure;
 
-    texture_sys_init();
-    mesh_sys_init();
     pt_sys_init();
     EnsureFramebuf();
 
@@ -1092,11 +1092,7 @@ static i32 CreateQuad(const char* name, float4 center, float4 forward, float4 up
     dr->scales[i] = f4_s(scale);
     dr->rotations[i] = quat_lookat(forward, up);
 
-    material_t mat =
-    {
-        .flatAlbedo = albedo,
-        .flatRome = rome,
-    };
+    material_t mat = { 0 };
     dr->materials[i] = mat;
 
     return i;
@@ -1119,11 +1115,7 @@ static i32 CreateSphere(const char* name, float4 center, float radius, float4 al
     dr->scales[i] = f4_s(radius);
     dr->rotations[i] = quat_id;
 
-    material_t mat =
-    {
-        .flatAlbedo = albedo,
-        .flatRome = rome,
-    };
+    material_t mat = { 0 };
     dr->materials[i] = mat;
 
     return i;

--- a/src/rendering/resolve_tile.c
+++ b/src/rendering/resolve_tile.c
@@ -15,7 +15,7 @@ typedef struct resolve_s
     TonemapId tmapId;
 } resolve_t;
 
-pim_inline u32 VEC_CALL ToColor(prng_t* rng, float4 linear)
+pim_inline u32 VEC_CALL ToColor(prng_t *const pim_noalias rng, float4 linear)
 {
     const float4 kWeight = { 1.0f / 255.0f, 1.0f / 255.0f, 1.0f / 255.0f, 0.0f };
     float4 srgb = f4_tosrgb(linear);

--- a/src/rendering/texture.h
+++ b/src/rendering/texture.h
@@ -11,12 +11,6 @@ PIM_C_BEGIN
 typedef struct table_s table_t;
 typedef struct crate_s crate_t;
 
-typedef struct textureid_s
-{
-    u32 index : 24;
-    u32 version : 8;
-} textureid_t;
-
 typedef struct dtextureid_s
 {
     guid_t id;
@@ -25,7 +19,7 @@ typedef struct dtextureid_s
 typedef struct texture_s
 {
     int2 size;
-    u32* pim_noalias texels;
+    void* pim_noalias texels;
     vkrTexture2D vkrtex;
 } texture_t;
 
@@ -68,6 +62,7 @@ bool texture_unpalette(
     int2 size,
     const char* name,
     u32 matflags,
+    float4 flatRome,
     textureid_t* albedoOut,
     textureid_t* romeOut,
     textureid_t* normalOut);

--- a/src/rendering/texture.h
+++ b/src/rendering/texture.h
@@ -11,6 +11,12 @@ PIM_C_BEGIN
 typedef struct table_s table_t;
 typedef struct crate_s crate_t;
 
+typedef struct textureid_s
+{
+    u32 index : 24;
+    u32 version : 8;
+} textureid_t;
+
 typedef struct dtextureid_s
 {
     guid_t id;
@@ -20,7 +26,8 @@ typedef struct texture_s
 {
     int2 size;
     void* pim_noalias texels;
-    vkrTexture2D vkrtex;
+    VkFormat format;
+    vkrTextureId slot;
 } texture_t;
 
 #define kTextureVersion 5
@@ -37,8 +44,6 @@ const table_t* texture_table(void);
 void texture_sys_init(void);
 void texture_sys_update(void);
 void texture_sys_shutdown(void);
-// free vulkan resources
-void texture_sys_vkfree(void);
 void texture_sys_gui(bool* pEnabled);
 
 bool texture_loadat(const char* path, VkFormat format, textureid_t* idOut);

--- a/src/rendering/vulkan/vkr.c
+++ b/src/rendering/vulkan/vkr.c
@@ -114,7 +114,7 @@ bool vkr_init(void)
         goto cleanup;
     }
 
-    if (!vkrTexTable_New(&g_vkr.texTable))
+    if (!vkrTexTable_Init())
     {
         success = false;
         goto cleanup;
@@ -185,7 +185,7 @@ void vkr_update(void)
     VkCommandBuffer cmd = NULL;
     vkrSwapchain_AcquireSync(chain, &cmd, &fence);
     vkrAllocator_Update(&g_vkr.allocator);
-    vkrTexTable_Update(&g_vkr.texTable);
+    vkrTexTable_Update();
     vkrCmdBegin(cmd);
     vkrMainPass_Draw(&g_vkr.mainPass, cmd, fence);
     vkrCmdEnd(cmd);
@@ -208,13 +208,12 @@ void vkr_shutdown(void)
     {
         vkrDevice_WaitIdle();
 
-        texture_sys_vkfree();
         lmpack_del(lmpack_get());
         ui_sys_shutdown();
 
         vkrExposurePass_Del(&g_vkr.exposurePass);
         vkrMainPass_Del(&g_vkr.mainPass);
-        vkrTexTable_Del(&g_vkr.texTable);
+        vkrTexTable_Shutdown();
 
         vkrAllocator_Finalize(&g_vkr.allocator);
 

--- a/src/rendering/vulkan/vkr.c
+++ b/src/rendering/vulkan/vkr.c
@@ -208,7 +208,6 @@ void vkr_shutdown(void)
     {
         vkrDevice_WaitIdle();
 
-        mesh_sys_vkfree();
         texture_sys_vkfree();
         lmpack_del(lmpack_get());
         ui_sys_shutdown();

--- a/src/rendering/vulkan/vkr.h
+++ b/src/rendering/vulkan/vkr.h
@@ -4,6 +4,7 @@
 #include <volk/volk.h>
 #include "math/types.h"
 #include "containers/strlist.h"
+#include "containers/queue.h"
 #include "threading/mutex.h"
 
 PIM_C_BEGIN
@@ -13,12 +14,6 @@ PIM_C_BEGIN
 PIM_FWD_DECL(GLFWwindow);
 PIM_DECL_HANDLE(VmaAllocator);
 PIM_DECL_HANDLE(VmaAllocation);
-
-typedef struct textureid_s
-{
-    u32 index : 24;
-    u32 version : 8;
-} textureid_t;
 
 typedef enum
 {
@@ -153,6 +148,16 @@ typedef struct vkrMesh
     vkrBuffer buffer;
     i32 vertCount;
 } vkrMesh;
+
+typedef union vkrTextureId
+{
+    struct
+    {
+        u32 index : 24;
+        u32 version : 8;
+    };
+    u32 asint;
+} vkrTextureId;
 
 typedef struct vkrImage
 {
@@ -365,12 +370,6 @@ typedef struct vkrAllocator
     mutex_t releasemtx;
 } vkrAllocator;
 
-typedef struct vkrTexTable
-{
-    vkrTexture2D black;
-    VkDescriptorImageInfo table[kTextureDescriptors];
-} vkrTexTable;
-
 typedef struct vkrPassContext
 {
     VkRenderPass renderPass;
@@ -424,8 +423,8 @@ typedef struct vkrScreenBlit
 typedef struct vkrDepthPass
 {
     vkrPass pass;
-    vkrBuffer stagebuf;
-    vkrBuffer meshbuf;
+    vkrBuffer stagebufs[kFramesInFlight];
+    vkrBuffer meshbufs[kFramesInFlight];
     i32 vertCount;
 } vkrDepthPass;
 
@@ -468,7 +467,7 @@ typedef struct vkrUIPass
     vkrPass pass;
     vkrBuffer vertbufs[kFramesInFlight];
     vkrBuffer indbufs[kFramesInFlight];
-    textureid_t font;
+    vkrTextureId font;
 } vkrUIPass;
 
 typedef struct vkrExposure
@@ -543,7 +542,6 @@ typedef struct vkr_t
 
     vkrMainPass mainPass;
     vkrExposurePass exposurePass;
-    vkrTexTable texTable;
 } vkr_t;
 extern vkr_t g_vkr;
 

--- a/src/rendering/vulkan/vkr.h
+++ b/src/rendering/vulkan/vkr.h
@@ -14,6 +14,12 @@ PIM_FWD_DECL(GLFWwindow);
 PIM_DECL_HANDLE(VmaAllocator);
 PIM_DECL_HANDLE(VmaAllocation);
 
+typedef struct textureid_s
+{
+    u32 index : 24;
+    u32 version : 8;
+} textureid_t;
+
 typedef enum
 {
     kMaxSwapchainLen = 3,
@@ -62,9 +68,10 @@ typedef enum
 
 typedef enum
 {
-    vkrMeshStream_Position, // float4; xyz=positionOS
-    vkrMeshStream_Normal,   // float4; xyz=normalOS, w=uv1 image index
-    vkrMeshStream_Uv01,     // float4; xy=uv0, zw=uv1
+    vkrMeshStream_Position,     // float4; xyz=positionOS
+    vkrMeshStream_Normal,       // float4; xyz=normalOS, w=uv1 image index
+    vkrMeshStream_Uv01,         // float4; xy=uv0, zw=uv1
+    vkrMeshStream_TexIndices,   // int4; albedo, rome, normal, lightmap index
 
     vkrMeshStream_COUNT
 } vkrMeshStream;
@@ -145,7 +152,6 @@ typedef struct vkrMesh
 {
     vkrBuffer buffer;
     i32 vertCount;
-    i32 indexCount;
 } vkrMesh;
 
 typedef struct vkrImage
@@ -167,7 +173,6 @@ typedef struct vkrTexture2D
     vkrImage image;
     VkSampler sampler;
     VkImageView view;
-    i32 slot;
 } vkrTexture2D;
 
 typedef struct vkrAttachment
@@ -364,7 +369,6 @@ typedef struct vkrTexTable
 {
     vkrTexture2D black;
     VkDescriptorImageInfo table[kTextureDescriptors];
-    i32 width;
 } vkrTexTable;
 
 typedef struct vkrPassContext
@@ -417,14 +421,12 @@ typedef struct vkrScreenBlit
     i32 height;
 } vkrScreenBlit;
 
-typedef struct vkrDepthPc
-{
-    float4x4 localToClip;
-} vkrDepthPc;
-
 typedef struct vkrDepthPass
 {
     vkrPass pass;
+    vkrBuffer stagebuf;
+    vkrBuffer meshbuf;
+    i32 vertCount;
 } vkrDepthPass;
 
 typedef struct vkrPerCamera
@@ -466,7 +468,7 @@ typedef struct vkrUIPass
     vkrPass pass;
     vkrBuffer vertbufs[kFramesInFlight];
     vkrBuffer indbufs[kFramesInFlight];
-    vkrTexture2D font;
+    textureid_t font;
 } vkrUIPass;
 
 typedef struct vkrExposure

--- a/src/rendering/vulkan/vkr_buffer.c
+++ b/src/rendering/vulkan/vkr_buffer.c
@@ -81,7 +81,6 @@ bool vkrBuffer_Reserve(
     VkFence fence,
     const char* tag)
 {
-    ProfileBegin(pm_bufreserve);
     bool success = true;
     i32 oldsize = buffer->size;
     ASSERT(buffer);
@@ -89,16 +88,12 @@ bool vkrBuffer_Reserve(
     ASSERT(oldsize >= 0);
     if (oldsize < size)
     {
+        ProfileBegin(pm_bufreserve);
         vkrBuffer_Release(buffer, fence);
         size = (size > oldsize * 2) ? size : oldsize * 2;
-        if (!vkrBuffer_New(buffer, size, bufferUsage, memUsage, tag))
-        {
-            success = false;
-            goto cleanup;
-        }
+        success = vkrBuffer_New(buffer, size, bufferUsage, memUsage, tag);
+        ProfileEnd(pm_bufreserve);
     }
-cleanup:
-    ProfileEnd(pm_bufreserve);
     return success;
 }
 

--- a/src/rendering/vulkan/vkr_buffer.c
+++ b/src/rendering/vulkan/vkr_buffer.c
@@ -28,7 +28,7 @@ bool vkrBuffer_New(
         .usage = bufferUsage,
         .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
     };
-    const VmaAllocationCreateInfo allocInfo =
+    VmaAllocationCreateInfo allocInfo =
     {
         .flags = VMA_ALLOCATION_CREATE_WITHIN_BUDGET_BIT,
         .usage = memUsage,

--- a/src/rendering/vulkan/vkr_cmd.c
+++ b/src/rendering/vulkan/vkr_cmd.c
@@ -410,17 +410,15 @@ void vkrCmdDrawMesh(VkCommandBuffer cmdbuf, const vkrMesh* mesh)
 {
     ASSERT(mesh);
     ASSERT(cmdbuf);
-    ASSERT(cmdbuf);
     ASSERT(mesh->vertCount >= 0);
-    ASSERT(mesh->indexCount >= 0);
     ASSERT(mesh->buffer.handle);
 
     if (mesh->vertCount > 0)
     {
         const VkDeviceSize streamSize = sizeof(float4) * mesh->vertCount;
-        const VkDeviceSize indexOffset = streamSize * vkrMeshStream_COUNT;
         const VkBuffer buffers[] =
         {
+            mesh->buffer.handle,
             mesh->buffer.handle,
             mesh->buffer.handle,
             mesh->buffer.handle,
@@ -430,17 +428,10 @@ void vkrCmdDrawMesh(VkCommandBuffer cmdbuf, const vkrMesh* mesh)
             streamSize * 0,
             streamSize * 1,
             streamSize * 2,
+            streamSize * 3,
         };
         vkCmdBindVertexBuffers(cmdbuf, 0, NELEM(buffers), buffers, offsets);
-        if (mesh->indexCount > 0)
-        {
-            vkCmdBindIndexBuffer(cmdbuf, mesh->buffer.handle, indexOffset, VK_INDEX_TYPE_UINT16);
-            vkCmdDrawIndexed(cmdbuf, mesh->indexCount, 1, 0, 0, 0);
-        }
-        else
-        {
-            vkCmdDraw(cmdbuf, mesh->vertCount, 1, 0, 0);
-        }
+        vkCmdDraw(cmdbuf, mesh->vertCount, 1, 0, 0);
     }
 }
 

--- a/src/rendering/vulkan/vkr_depthpass.c
+++ b/src/rendering/vulkan/vkr_depthpass.c
@@ -5,10 +5,13 @@
 #include "rendering/vulkan/vkr_context.h"
 #include "rendering/vulkan/vkr_swapchain.h"
 #include "rendering/vulkan/vkr_cmd.h"
+#include "rendering/vulkan/vkr_buffer.h"
+#include "rendering/vulkan/vkr_mesh.h"
 
 #include "rendering/drawable.h"
 #include "rendering/mesh.h"
 #include "rendering/camera.h"
+#include "rendering/material.h"
 
 #include "allocator/allocator.h"
 #include "common/profiler.h"
@@ -45,7 +48,7 @@ bool vkrDepthPass_New(vkrDepthPass* pass, VkRenderPass renderPass)
     {
         {
             .stageFlags = VK_SHADER_STAGE_VERTEX_BIT,
-            .size = sizeof(vkrOpaquePc),
+            .size = sizeof(float4x4),
         },
     };
     const VkVertexInputBindingDescription vertBindings[] =
@@ -128,6 +131,8 @@ void vkrDepthPass_Del(vkrDepthPass* pass)
     if (pass)
     {
         vkrPass_Del(&pass->pass);
+        vkrBuffer_Del(&pass->stagebuf);
+        vkrBuffer_Del(&pass->meshbuf);
         memset(pass, 0, sizeof(*pass));
     }
 }
@@ -142,47 +147,25 @@ void vkrDepthPass_Draw(const vkrPassContext* passCtx, vkrDepthPass* pass)
 
 // ----------------------------------------------------------------------------
 
-typedef struct vkrTaskDraw
+ProfileMark(pm_execute, vkrDepthPass_Execute)
+static vkrDepthPass_Execute(const vkrPassContext* ctx, vkrDepthPass* pass)
 {
-    task_t task;
-    frus_t frustum;
-    float4x4 worldToClip;
-    vkrDepthPass* pass;
-    VkRenderPass renderPass;
-    vkrPassId subpass;
-    const vkrSwapchain* chain;
-    VkFramebuffer framebuffer;
-    VkFence primaryFence;
-    const drawables_t* drawables;
-    VkCommandBuffer* buffers;
-    float* distances;
-} vkrTaskDraw;
+    ProfileBegin(pm_execute);
 
-static void vkrTaskDrawFn(void* pbase, i32 begin, i32 end)
-{
-    vkrTaskDraw* task = pbase;
-    vkrDepthPass* pass = task->pass;
-    const vkrSwapchain* chain = task->chain;
-    VkRenderPass renderPass = task->renderPass;
-    VkPipeline pipeline = pass->pass.pipeline;
-    VkPipelineLayout layout = pass->pass.layout;
-    vkrPassId subpass = task->subpass;
-    VkFramebuffer framebuffer = task->framebuffer;
-    VkFence primaryFence = task->primaryFence;
-    const drawables_t* drawables = task->drawables;
-    VkCommandBuffer* pim_noalias buffers = task->buffers;
-    float* pim_noalias distances = task->distances;
-    const VkPipelineBindPoint bindpoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
-
+    const vkrSwapchain* chain = &g_vkr.chain;
     VkRect2D rect = vkrSwapchain_GetRect(chain);
     VkViewport viewport = vkrSwapchain_GetViewport(chain);
+    const float aspect = viewport.width / viewport.height;
 
-    const meshid_t* pim_noalias meshids = drawables->meshes;
-    const float4x4* pim_noalias matrices = drawables->matrices;
-    const box_t* pim_noalias localBounds = drawables->bounds;
-
-    float4x4 worldToClip = task->worldToClip;
-    frus_t frustum = task->frustum;
+    camera_t camera;
+    camera_get(&camera);
+    float4 at = f4_add(camera.position, quat_fwd(camera.rotation));
+    float4 up = quat_up(camera.rotation);
+    float4x4 view = f4x4_lookat(camera.position, at, up);
+    float4x4 proj = f4x4_vkperspective(f1_radians(camera.fovy), aspect, camera.zNear, camera.zFar);
+    float4x4 worldToClip = f4x4_mul(proj, view);
+    frus_t frustum;
+    camera_frustum(&camera, &frustum, aspect);
     plane_t fwd = frustum.z0;
     {
         // frustum has outward facing planes
@@ -192,109 +175,144 @@ static void vkrTaskDrawFn(void* pbase, i32 begin, i32 end)
         fwd.value.w = w;
     }
 
-    vkrThreadContext* ctx = vkrContext_Get();
-    for (i32 i = begin; i < end; ++i)
+    drawables_t const *const drawables = drawables_get();
+    const i32 drawcount = drawables->count;
+    meshid_t const *const pim_noalias meshids = drawables->meshes;
+    float4x4 const *const pim_noalias matrices = drawables->matrices;
+    float3x3 const *const pim_noalias invMatrices = drawables->invMatrices;
+    box_t const *const pim_noalias localBounds = drawables->bounds;
+    material_t const *const pim_noalias materials = drawables->materials;
+
+    i32 visibleDrawCount = 0;
+    i32 visibleVertCount = 0;
+    i32* pim_noalias visibleIndices = NULL;
+    for (i32 i = 0; i < drawcount; ++i)
     {
-        buffers[i] = NULL;
-        distances[i] = 1 << 20;
         float4x4 localToWorld = matrices[i];
         box_t bounds = box_transform(localToWorld, localBounds[i]);
         if (sdFrusBox(frustum, bounds) > 0.0f)
         {
             continue;
         }
-        mesh_t const *const mesh = mesh_get(meshids[i]);
-        if (mesh)
+        const mesh_t* pMesh = mesh_get(meshids[i]);
+        if (!pMesh)
         {
-            distances[i] = sdPlaneBox3D(fwd, bounds);
-            VkCommandBuffer cmd = vkrContext_GetSecCmd(ctx, vkrQueueId_Gfx, primaryFence);
-            buffers[i] = cmd;
-            vkrCmdBeginSec(cmd, renderPass, subpass, framebuffer);
-            vkrCmdViewport(cmd, viewport, rect);
-            vkCmdBindPipeline(cmd, bindpoint, pipeline);
-            const vkrDepthPc pushConsts =
-            {
-                .localToClip = f4x4_mul(worldToClip, localToWorld),
-            };
-            vkrCmdPushConstants(cmd, layout, VK_SHADER_STAGE_VERTEX_BIT, &pushConsts, sizeof(pushConsts));
-            const VkDeviceSize offset = {0};
-            vkCmdBindVertexBuffers(cmd, 0, 1, &mesh->vkrmesh.buffer.handle, &offset);
-            vkCmdDraw(cmd, mesh->vkrmesh.vertCount, 1, 0, 0);
-            vkrCmdEnd(cmd);
+            continue;
         }
-    }
-}
-
-ProfileMark(pm_execute, vkrDepthPass_Execute)
-static vkrDepthPass_Execute(const vkrPassContext* ctx, vkrDepthPass* pass)
-{
-    ProfileBegin(pm_execute);
-
-    const vkrSwapchain* chain = &g_vkr.chain;
-    const drawables_t* drawables = drawables_get();
-	i32 drawcount = drawables->count;
-	const i32 width = chain->width;
-	const i32 height = chain->height;
-	const float aspect = (float)width / (float)height;
-
-    camera_t camera;
-    camera_get(&camera);
-    float4 at = f4_add(camera.position, quat_fwd(camera.rotation));
-    float4 up = quat_up(camera.rotation);
-    float4x4 view = f4x4_lookat(camera.position, at, up);
-    float4x4 proj = f4x4_vkperspective(f1_radians(camera.fovy), aspect, camera.zNear, camera.zFar);
-
-    VkCommandBuffer* pim_noalias buffers = tmp_calloc(sizeof(buffers[0]) * drawcount);
-    float* pim_noalias distances = tmp_calloc(sizeof(distances[0]) * drawcount);
-    vkrTaskDraw* task = tmp_calloc(sizeof(*task));
-
-    task->buffers = buffers;
-    task->chain = chain;
-    task->distances = distances;
-    task->drawables = drawables;
-    task->framebuffer = ctx->framebuffer;
-    camera_frustum(&camera, &task->frustum, aspect);
-    task->pass = pass;
-    task->primaryFence = ctx->fence;
-    task->renderPass = ctx->renderPass;
-    task->subpass = ctx->subpass;
-    task->worldToClip = f4x4_mul(proj, view);
-
-    task_run(task, vkrTaskDrawFn, drawcount);
-
-    for (i32 i = 0; i < drawcount; ++i)
-    {
-        if (!buffers[i])
-        {
-            buffers[i] = buffers[drawcount - 1];
-            distances[i] = distances[drawcount - 1];
-            --drawcount;
-            --i;
-        }
+        ++visibleDrawCount;
+        visibleIndices = tmp_realloc(visibleIndices, sizeof(visibleIndices[0]) * visibleDrawCount);
+        visibleIndices[visibleDrawCount - 1] = i;
+        visibleVertCount += pMesh->length;
     }
 
-    for (i32 i = 0; i < drawcount; ++i)
+    pass->vertCount = visibleVertCount;
+    const i32 meshBytes = (sizeof(float4) * 4) * visibleVertCount;
+    vkrBuffer *const stageBuf = &pass->stagebuf;
+    vkrBuffer *const meshBuf = &pass->meshbuf;
+    vkrBuffer_Reserve(
+        stageBuf,
+        meshBytes,
+        VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
+        vkrMemUsage_CpuOnly,
+        NULL,
+        PIM_FILELINE);
+    vkrBuffer_Reserve(
+        meshBuf,
+        meshBytes,
+        VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT,
+        vkrMemUsage_GpuOnly,
+        NULL,
+        PIM_FILELINE);
+
     {
-        i32 c = i;
-        for (i32 j = i + 1; j < drawcount; ++j)
+        i32 vertCount = 0;
+        float4 *const pim_noalias positions = vkrBuffer_Map(stageBuf);
+        float4 *const pim_noalias normals = positions + visibleVertCount;
+        float4 *const pim_noalias uv01s = normals + visibleVertCount;
+        int4 *const pim_noalias texIndices = (int4*)(uv01s + visibleVertCount);
+        for (i32 iVis = 0; iVis < visibleDrawCount; ++iVis)
         {
-            if (distances[j] < distances[c])
+            const i32 iMesh = visibleIndices[iVis];
+            const mesh_t mesh = *mesh_get(meshids[iMesh]);
+            const i32 vertBack = vertCount;
+            vertCount += mesh.length;
+
+            const float4x4 localToWorld = matrices[iMesh];
+            for (i32 j = 0; j < mesh.length; ++j)
             {
-                c = j;
+                positions[vertBack + j] = f4x4_mul_pt(localToWorld, mesh.positions[j]);
+            }
+
+            const float3x3 IM = invMatrices[iMesh];
+            for (i32 j = 0; j < mesh.length; ++j)
+            {
+                normals[vertBack + j] = f3x3_mul_col(IM, mesh.normals[j]);
+            }
+
+            memcpy(uv01s + vertBack, mesh.uvs, sizeof(uv01s[0]) * mesh.length);
+
+            const material_t mat = materials[iMesh];
+            int4 texIdx = { mat.albedo.index, mat.rome.index, mat.normal.index, 0 };
+            for (i32 j = 0; j < mesh.length; ++j)
+            {
+                texIdx.w = (i32)mesh.normals[j].w;
+                texIndices[vertBack + j] = texIdx;
             }
         }
-        if (c != i)
-        {
-            float t0 = distances[i];
-            distances[i] = distances[c];
-            distances[c] = t0;
-            VkCommandBuffer t1 = buffers[i];
-            buffers[i] = buffers[c];
-            buffers[c] = t1;
-        }
+        ASSERT(vertCount == visibleVertCount);
+        vkrBuffer_Unmap(stageBuf);
+        vkrBuffer_Flush(stageBuf);
     }
 
-    vkrCmdExecCmds(ctx->cmd, drawcount, buffers);
+    {
+        VkFence fence = NULL;
+        VkQueue queue = NULL;
+        VkCommandBuffer cpyCmd = vkrContext_GetTmpCmd(vkrContext_Get(), vkrQueueId_Gfx, &fence, &queue);
+        vkrCmdBegin(cpyCmd);
+        vkrCmdCopyBuffer(cpyCmd, *stageBuf, *meshBuf);
+        vkrBuffer_Barrier(
+            meshBuf,
+            cpyCmd,
+            VK_ACCESS_TRANSFER_WRITE_BIT,
+            VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT,
+            VK_PIPELINE_STAGE_TRANSFER_BIT,
+            VK_PIPELINE_STAGE_VERTEX_INPUT_BIT);
+        vkrCmdEnd(cpyCmd);
+        vkrCmdSubmit(queue, cpyCmd, fence, NULL, 0x0, NULL);
+    }
+
+    VkRenderPass renderPass = ctx->renderPass;
+    VkPipeline pipeline = pass->pass.pipeline;
+    VkPipelineLayout layout = pass->pass.layout;
+    VkCommandBuffer cmd = ctx->cmd;
+
+    vkrCmdViewport(cmd, viewport, rect);
+    vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline);
+
+    struct
+    {
+        float4x4 worldToClip;
+    } pushConsts;
+    pushConsts.worldToClip = worldToClip;
+    vkCmdPushConstants(
+        cmd,
+        layout,
+        VK_SHADER_STAGE_VERTEX_BIT,
+        0,
+        sizeof(pushConsts),
+        &pushConsts);
+
+    // position only
+    const VkBuffer buffers[] =
+    {
+        meshBuf->handle,
+    };
+    const VkDeviceSize offsets[] =
+    {
+        0,
+    };
+    vkCmdBindVertexBuffers(cmd, 0, NELEM(buffers), buffers, offsets);
+    vkCmdDraw(cmd, visibleVertCount, 1, 0, 0);
 
     ProfileEnd(pm_execute);
 }

--- a/src/rendering/vulkan/vkr_mainpass.c
+++ b/src/rendering/vulkan/vkr_mainpass.c
@@ -183,7 +183,7 @@ void vkrMainPass_Draw(
         rect,
         NELEM(clearValues),
         clearValues,
-        VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS);
+        VK_SUBPASS_CONTENTS_INLINE);
     passCtx.subpass = 0;
 
     if (!r_sw)
@@ -191,7 +191,7 @@ void vkrMainPass_Draw(
         vkrDepthPass_Draw(&passCtx, &pass->depth);
     }
 
-    vkrCmdNextSubpass(cmd, VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS);
+    vkrCmdNextSubpass(cmd, VK_SUBPASS_CONTENTS_INLINE);
     passCtx.subpass++;
 
     if (!r_sw)
@@ -199,7 +199,7 @@ void vkrMainPass_Draw(
         vkrOpaquePass_Draw(&passCtx, &pass->opaque);
     }
 
-    vkrCmdNextSubpass(cmd, VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS);
+    vkrCmdNextSubpass(cmd, VK_SUBPASS_CONTENTS_INLINE);
     passCtx.subpass++;
 
     vkrUIPass_Draw(&passCtx, &pass->ui);

--- a/src/rendering/vulkan/vkr_mesh.h
+++ b/src/rendering/vulkan/vkr_mesh.h
@@ -11,8 +11,7 @@ bool vkrMesh_New(
     const float4* pim_noalias positions,
     const float4* pim_noalias normals,
     const float4* pim_noalias uv01,
-    i32 indexCount,
-    const u16* pim_noalias indices);
+    const int4* pim_noalias texIndices);
 void vkrMesh_Del(vkrMesh* mesh);
 
 bool vkrMesh_Upload(
@@ -21,7 +20,6 @@ bool vkrMesh_Upload(
     const float4* pim_noalias positions,
     const float4* pim_noalias normals,
     const float4* pim_noalias uv01,
-    i32 indexCount,
-    const u16* pim_noalias indices);
+    const int4* pim_noalias texIndices);
 
 PIM_C_END

--- a/src/rendering/vulkan/vkr_opaquepass.c
+++ b/src/rendering/vulkan/vkr_opaquepass.c
@@ -62,11 +62,11 @@ bool vkrOpaquePass_New(vkrOpaquePass* pass, VkRenderPass renderPass)
     }
 
     const VkDescriptorPoolSize poolSizes[] =
-	{
-		{
-			.type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
-			.descriptorCount = 1,
-		},
+    {
+        {
+            .type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+            .descriptorCount = 1,
+        },
         {
             .type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
             .descriptorCount = 1,
@@ -91,31 +91,24 @@ bool vkrOpaquePass_New(vkrOpaquePass* pass, VkRenderPass renderPass)
             .descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
             .descriptorCount = kTextureDescriptors,
             .stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT,
-		},
-		{
-			// exposure storage buffer
-			.binding = 3,
-			.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
-			.descriptorCount = 1,
-			.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT,
-		},
-    };
-    const VkPushConstantRange ranges[] =
-    {
+        },
         {
-            .stageFlags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT,
-            .size = sizeof(vkrOpaquePc),
+            // exposure storage buffer
+            .binding = 3,
+            .descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+            .descriptorCount = 1,
+            .stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT,
         },
     };
     const VkVertexInputBindingDescription vertBindings[] =
     {
-        // positionOS
+        // positionWS
         {
             .binding = 0,
             .stride = sizeof(float4),
             .inputRate = VK_VERTEX_INPUT_RATE_VERTEX,
         },
-        // normalOS and lightmap index
+        // normalWS and lightmap index
         {
             .binding = 1,
             .stride = sizeof(float4),
@@ -125,6 +118,12 @@ bool vkrOpaquePass_New(vkrOpaquePass* pass, VkRenderPass renderPass)
         {
             .binding = 2,
             .stride = sizeof(float4),
+            .inputRate = VK_VERTEX_INPUT_RATE_VERTEX,
+        },
+        // texture indices
+        {
+            .binding = 3,
+            .stride = sizeof(int4),
             .inputRate = VK_VERTEX_INPUT_RATE_VERTEX,
         },
     };
@@ -133,21 +132,27 @@ bool vkrOpaquePass_New(vkrOpaquePass* pass, VkRenderPass renderPass)
         // positionOS
         {
             .binding = 0,
-            .format = VK_FORMAT_R32G32B32A32_SFLOAT,
             .location = 0,
+            .format = VK_FORMAT_R32G32B32A32_SFLOAT,
         },
         // normalOS and lightmap index
         {
             .binding = 1,
-            .format = VK_FORMAT_R32G32B32A32_SFLOAT,
             .location = 1,
+            .format = VK_FORMAT_R32G32B32A32_SFLOAT,
         },
         // uv0 and uv1
         {
             .binding = 2,
-            .format = VK_FORMAT_R32G32B32A32_SFLOAT,
             .location = 2,
+            .format = VK_FORMAT_R32G32B32A32_SFLOAT,
         },
+        // texture indices
+        {
+            .binding = 3,
+            .location = 3,
+            .format = VK_FORMAT_R32G32B32A32_UINT,
+        }
     };
 
     const vkrPassDesc desc =
@@ -191,8 +196,6 @@ bool vkrOpaquePass_New(vkrOpaquePass* pass, VkRenderPass renderPass)
         .poolSizes = poolSizes,
         .bindingCount = NELEM(bindings),
         .bindings = bindings,
-        .rangeCount = NELEM(ranges),
-        .ranges = ranges,
         .shaderCount = NELEM(shaders),
         .shaders = shaders,
     };
@@ -252,164 +255,35 @@ typedef struct vkrTaskDraw
     float* distances;
 } vkrTaskDraw;
 
-static void vkrTaskDrawFn(void* pbase, i32 begin, i32 end)
-{
-    vkrTaskDraw* task = pbase;
-    vkrOpaquePass* pass = task->pass;
-    const vkrSwapchain* chain = task->chain;
-    VkRenderPass renderPass = task->renderPass;
-    VkPipeline pipeline = pass->pass.pipeline;
-    VkPipelineLayout layout = pass->pass.layout;
-    vkrPassId subpass = task->subpass;
-    VkDescriptorSet descSet = task->descSet;
-    VkFramebuffer framebuffer = task->framebuffer;
-    VkFence primaryFence = task->primaryFence;
-    const drawables_t* drawables = task->drawables;
-    VkCommandBuffer* pim_noalias buffers = task->buffers;
-    float* pim_noalias distances = task->distances;
-    const VkPipelineBindPoint bindpoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
-
-    VkRect2D rect = vkrSwapchain_GetRect(chain);
-    VkViewport viewport = vkrSwapchain_GetViewport(chain);
-    const VkClearValue clearValues[] =
-    {
-        {
-            .color = { 0.0f, 0.0f, 0.0f, 1.0f },
-        },
-        {
-            .depthStencil = { 1.0f, 0 },
-        },
-    };
-
-    const meshid_t* pim_noalias meshids = drawables->meshes;
-    const material_t* pim_noalias materials = drawables->materials;
-    const float4x4* pim_noalias matrices = drawables->matrices;
-    const float3x3* pim_noalias invMatrices = drawables->invMatrices;
-    const box_t* pim_noalias localBounds = drawables->bounds;
-    const texture_t* pim_noalias textures = texture_table()->values;
-
-    frus_t frustum = task->frustum;
-    plane_t fwd = frustum.z0;
-    {
-        // frustum has outward facing planes
-        // we want forward plane for depth sorting draw calls
-        float w = fwd.value.w;
-        fwd.value = f4_neg(fwd.value);
-        fwd.value.w = w;
-    }
-
-    vkrThreadContext* ctx = vkrContext_Get();
-    for (i32 i = begin; i < end; ++i)
-    {
-        buffers[i] = NULL;
-        distances[i] = 1 << 20;
-        float4x4 matrix = matrices[i];
-        box_t bounds = box_transform(matrix, localBounds[i]);
-        if (sdFrusBox(frustum, bounds) > 0.0f)
-        {
-            continue;
-        }
-        mesh_t const *const mesh = mesh_get(meshids[i]);
-        if (mesh)
-        {
-            distances[i] = sdPlaneBox3D(fwd, bounds);
-            VkCommandBuffer cmd = vkrContext_GetSecCmd(ctx, vkrQueueId_Gfx, primaryFence);
-            buffers[i] = cmd;
-            vkrCmdBeginSec(cmd, renderPass, subpass, framebuffer);
-            vkrCmdViewport(cmd, viewport, rect);
-            vkCmdBindPipeline(cmd, bindpoint, pipeline);
-            vkrCmdBindDescSets(cmd, bindpoint, layout, 1, &descSet);
-
-            i32 iAlbedo = materials[i].albedo.index;
-            i32 iRome = materials[i].rome.index;
-            i32 iNormal = materials[i].normal.index;
-            iAlbedo = textures[iAlbedo].vkrtex.slot;
-            iRome = textures[iRome].vkrtex.slot;
-            iNormal = textures[iNormal].vkrtex.slot;
-            const vkrOpaquePc pushConsts =
-            {
-                .localToWorld = matrix,
-                .IMc0 = invMatrices[i].c0,
-                .IMc1 = invMatrices[i].c1,
-                .IMc2 = invMatrices[i].c2,
-                .flatRome = materials[i].flatRome,
-                .albedoIndex = iAlbedo,
-                .romeIndex = iRome,
-                .normalIndex = iNormal,
-            };
-            const u32 stages = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
-            vkrCmdPushConstants(cmd, layout, stages, &pushConsts, sizeof(pushConsts));
-            vkrCmdDrawMesh(cmd, &mesh->vkrmesh);
-            vkrCmdEnd(cmd);
-        }
-    }
-}
-
 ProfileMark(pm_execute, vkrOpaquePass_Execute)
 static vkrOpaquePass_Execute(const vkrPassContext* ctx, vkrOpaquePass* pass)
 {
     ProfileBegin(pm_execute);
 
-	const vkrSwapchain* chain = &g_vkr.chain;
-    const drawables_t* drawables = drawables_get();
-	i32 drawcount = drawables->count;
-	const i32 width = chain->width;
-	const i32 height = chain->height;
-	const float aspect = (float)width / (float)height;
+    VkCommandBuffer cmd = ctx->cmd;
+    vkrCmdViewport(cmd, vkrSwapchain_GetViewport(&g_vkr.chain), vkrSwapchain_GetRect(&g_vkr.chain));
+    vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, pass->pass.pipeline);
+    vkrCmdBindDescSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, pass->pass.layout, 1, &pass->pass.sets[ctx->syncIndex]);
 
-    VkCommandBuffer* pim_noalias buffers = tmp_calloc(sizeof(buffers[0]) * drawcount);
-    float* pim_noalias distances = tmp_calloc(sizeof(distances[0]) * drawcount);
-    vkrTaskDraw* task = tmp_calloc(sizeof(*task));
-
-    task->buffers = buffers;
-    task->chain = chain;
-    task->descSet = pass->pass.sets[ctx->syncIndex];
-    task->distances = distances;
-    task->drawables = drawables;
-    task->framebuffer = ctx->framebuffer;
-    camera_t camera;
-    camera_get(&camera);
-    camera_frustum(&camera, &task->frustum, aspect);
-    task->pass = pass;
-    task->primaryFence = ctx->fence;
-    task->renderPass = ctx->renderPass;
-    task->subpass = ctx->subpass;
-
-    task_run(task, vkrTaskDrawFn, drawcount);
-
-    for (i32 i = 0; i < drawcount; ++i)
+    VkBuffer mesh = g_vkr.mainPass.depth.meshbuf.handle;
+    const i32 vertCount = g_vkr.mainPass.depth.vertCount;
+    const i32 stride = vertCount * sizeof(float4);
+    const VkBuffer buffers[] =
     {
-        if (!buffers[i])
-        {
-            buffers[i] = buffers[drawcount - 1];
-            distances[i] = distances[drawcount - 1];
-            --drawcount;
-            --i;
-        }
-    }
-
-    for (i32 i = 0; i < drawcount; ++i)
+        mesh, // positions
+        mesh, // normals
+        mesh, // uvs
+        mesh, // texture indices
+    };
+    const VkDeviceSize offsets[] =
     {
-        i32 c = i;
-        for (i32 j = i + 1; j < drawcount; ++j)
-        {
-            if (distances[j] < distances[c])
-            {
-                c = j;
-            }
-        }
-        if (c != i)
-        {
-            float t0 = distances[i];
-            distances[i] = distances[c];
-            distances[c] = t0;
-            VkCommandBuffer t1 = buffers[i];
-            buffers[i] = buffers[c];
-            buffers[c] = t1;
-        }
-    }
-
-    vkrCmdExecCmds(ctx->cmd, drawcount, buffers);
+        stride * 0,
+        stride * 1,
+        stride * 2,
+        stride * 3,
+    };
+    vkCmdBindVertexBuffers(cmd, 0, NELEM(buffers), buffers, offsets);
+    vkCmdDraw(cmd, vertCount, 1, 0, 0);
 
     ProfileEnd(pm_execute);
 }
@@ -425,31 +299,31 @@ static vkrOpaquePass_Update(const vkrPassContext* passCtx, vkrOpaquePass* pass)
     VkBuffer expBuffer = g_vkr.exposurePass.expBuffers[syncIndex].handle;
 
     // update per camera buffer
-	{
-		const vkrSwapchain* chain = &g_vkr.chain;
-		float aspect = (float)chain->width / chain->height;
-		camera_t camera;
-		camera_get(&camera);
-		float4 at = f4_add(camera.position, quat_fwd(camera.rotation));
-		float4 up = quat_up(camera.rotation);
-		float4x4 view = f4x4_lookat(camera.position, at, up);
-		float4x4 proj = f4x4_vkperspective(f1_radians(camera.fovy), aspect, camera.zNear, camera.zFar);
+    {
+        const vkrSwapchain* chain = &g_vkr.chain;
+        float aspect = (float)chain->width / chain->height;
+        camera_t camera;
+        camera_get(&camera);
+        float4 at = f4_add(camera.position, quat_fwd(camera.rotation));
+        float4 up = quat_up(camera.rotation);
+        float4x4 view = f4x4_lookat(camera.position, at, up);
+        float4x4 proj = f4x4_vkperspective(f1_radians(camera.fovy), aspect, camera.zNear, camera.zFar);
 
         const lmpack_t* lmpack = lmpack_get();
         i32 lmBegin = kTextureDescriptors - kGiDirections;
         if (lmpack->lmCount > 0)
         {
-            lmBegin = lmpack->lightmaps[0].vkrtex[0].slot;
+            lmBegin = lmpack->lightmaps[0].ids[0].index;
         }
 
-		vkrPerCamera* perCamera = vkrBuffer_Map(camBuffer);
-		ASSERT(perCamera);
-		perCamera->worldToClip = f4x4_mul(proj, view);
-		perCamera->eye = camera.position;
-		perCamera->exposure = g_vkr.exposurePass.params.exposure;
-		perCamera->lmBegin = lmBegin;
-		vkrBuffer_Unmap(camBuffer);
-		vkrBuffer_Flush(camBuffer);
+        vkrPerCamera* perCamera = vkrBuffer_Map(camBuffer);
+        ASSERT(perCamera);
+        perCamera->worldToClip = f4x4_mul(proj, view);
+        perCamera->eye = camera.position;
+        perCamera->exposure = g_vkr.exposurePass.params.exposure;
+        perCamera->lmBegin = lmBegin;
+        vkrBuffer_Unmap(camBuffer);
+        vkrBuffer_Flush(camBuffer);
     }
 
     const vkrBinding bufferBindings[] =
@@ -463,17 +337,17 @@ static vkrOpaquePass_Update(const vkrPassContext* passCtx, vkrOpaquePass* pass)
                 .buffer = camBuffer->handle,
                 .range = VK_WHOLE_SIZE,
             },
-		},
-		{
-			.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
-			.set = set,
-			.binding = 3,
-			.buffer =
-			{
-				.buffer = expBuffer,
-				.range = VK_WHOLE_SIZE,
-			},
-		},
+        },
+        {
+            .type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+            .set = set,
+            .binding = 3,
+            .buffer =
+            {
+                .buffer = expBuffer,
+                .range = VK_WHOLE_SIZE,
+            },
+        },
     };
     vkrDesc_WriteBindings(NELEM(bufferBindings), bufferBindings);
 

--- a/src/rendering/vulkan/vkr_opaquepass.c
+++ b/src/rendering/vulkan/vkr_opaquepass.c
@@ -260,12 +260,13 @@ static vkrOpaquePass_Execute(const vkrPassContext* ctx, vkrOpaquePass* pass)
 {
     ProfileBegin(pm_execute);
 
+    const u32 syncIndex = ctx->syncIndex;
     VkCommandBuffer cmd = ctx->cmd;
     vkrCmdViewport(cmd, vkrSwapchain_GetViewport(&g_vkr.chain), vkrSwapchain_GetRect(&g_vkr.chain));
     vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, pass->pass.pipeline);
     vkrCmdBindDescSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, pass->pass.layout, 1, &pass->pass.sets[ctx->syncIndex]);
 
-    VkBuffer mesh = g_vkr.mainPass.depth.meshbuf.handle;
+    VkBuffer mesh = g_vkr.mainPass.depth.meshbufs[syncIndex].handle;
     const i32 vertCount = g_vkr.mainPass.depth.vertCount;
     const i32 stride = vertCount * sizeof(float4);
     const VkBuffer buffers[] =
@@ -313,7 +314,7 @@ static vkrOpaquePass_Update(const vkrPassContext* passCtx, vkrOpaquePass* pass)
         i32 lmBegin = kTextureDescriptors - kGiDirections;
         if (lmpack->lmCount > 0)
         {
-            lmBegin = lmpack->lightmaps[0].ids[0].index;
+            lmBegin = lmpack->lightmaps[0].slots[0].index;
         }
 
         vkrPerCamera* perCamera = vkrBuffer_Map(camBuffer);
@@ -351,7 +352,7 @@ static vkrOpaquePass_Update(const vkrPassContext* passCtx, vkrOpaquePass* pass)
     };
     vkrDesc_WriteBindings(NELEM(bufferBindings), bufferBindings);
 
-    vkrTexTable_Write(&g_vkr.texTable, set);
+    vkrTexTable_Write(set);
 
     ProfileEnd(pm_update);
 }

--- a/src/rendering/vulkan/vkr_pass.c
+++ b/src/rendering/vulkan/vkr_pass.c
@@ -26,23 +26,23 @@ bool vkrPass_New(vkrPass* pass, const vkrPassDesc* desc)
     }
 
     if (desc->poolSizeCount > 0)
-	{
-		pass->descPool = vkrDescPool_New(kFramesInFlight, desc->poolSizeCount, desc->poolSizes);
-		if (!pass->descPool)
-		{
-			vkrPass_Del(pass);
-			return false;
-		}
+    {
+        pass->descPool = vkrDescPool_New(kFramesInFlight, desc->poolSizeCount, desc->poolSizes);
+        if (!pass->descPool)
+        {
+            vkrPass_Del(pass);
+            return false;
+        }
 
-		for (i32 i = 0; i < kFramesInFlight; ++i)
-		{
-			pass->sets[i] = vkrDesc_New(pass->descPool, pass->setLayout);
-			if (!pass->sets[i])
-			{
-				vkrPass_Del(pass);
-				return false;
-			}
-		}
+        for (i32 i = 0; i < kFramesInFlight; ++i)
+        {
+            pass->sets[i] = vkrDesc_New(pass->descPool, pass->setLayout);
+            if (!pass->sets[i])
+            {
+                vkrPass_Del(pass);
+                return false;
+            }
+        }
     }
 
     switch (desc->bindpoint)

--- a/src/rendering/vulkan/vkr_textable.h
+++ b/src/rendering/vulkan/vkr_textable.h
@@ -4,20 +4,22 @@
 
 PIM_C_BEGIN
 
-bool vkrTexTable_New(vkrTexTable* table);
-void vkrTexTable_Del(vkrTexTable* table);
+bool vkrTexTable_Init(void);
+void vkrTexTable_Update(void);
+void vkrTexTable_Shutdown(void);
 
-void vkrTexTable_Update(vkrTexTable* table);
-void vkrTexTable_Write(const vkrTexTable* table, VkDescriptorSet set);
+void vkrTexTable_Write(VkDescriptorSet set);
 
-void vkrTexTable_ClearSlot(vkrTexTable* table, i32 slot);
-
-void vkrTexTable_WriteSlot(
-    vkrTexTable* table,
-    i32 slot,
-    VkSampler sampler,
-    VkImageView view,
-    VkImageLayout layout);
-
+bool vkrTexTable_Exists(vkrTextureId id);
+vkrTextureId vkrTexTable_Alloc(
+    i32 width,
+    i32 height,
+    VkFormat format,
+    const void* data);
+bool vkrTexTable_Free(vkrTextureId id);
+VkFence vkrTexTable_Upload(
+    vkrTextureId id,
+    const void* data,
+    i32 bytes);
 
 PIM_C_END

--- a/src/rendering/vulkan/vkr_textable.h
+++ b/src/rendering/vulkan/vkr_textable.h
@@ -10,15 +10,14 @@ void vkrTexTable_Del(vkrTexTable* table);
 void vkrTexTable_Update(vkrTexTable* table);
 void vkrTexTable_Write(const vkrTexTable* table, VkDescriptorSet set);
 
-i32 vkrTexTable_AllocSlot(vkrTexTable* table);
 void vkrTexTable_ClearSlot(vkrTexTable* table, i32 slot);
 
 void vkrTexTable_WriteSlot(
-	vkrTexTable* table,
-	i32 slot,
-	VkSampler sampler,
-	VkImageView view,
-	VkImageLayout layout);
+    vkrTexTable* table,
+    i32 slot,
+    VkSampler sampler,
+    VkImageView view,
+    VkImageLayout layout);
 
 
 PIM_C_END

--- a/src/rendering/vulkan/vkr_texture.c
+++ b/src/rendering/vulkan/vkr_texture.c
@@ -198,12 +198,9 @@ bool vkrTexture2D_New(
         goto cleanup;
     }
 
-    tex->slot = vkrTexTable_AllocSlot(&g_vkr.texTable);
-
     if (bytes > 0)
     {
         vkrTexture2D_Upload(tex, data, bytes);
-        ASSERT(tex->slot > 0);
     }
 
 cleanup:
@@ -218,7 +215,6 @@ void vkrTexture2D_Del(vkrTexture2D* tex)
 {
     if (tex)
     {
-        vkrTexTable_ClearSlot(&g_vkr.texTable, tex->slot);
         if (tex->image.handle)
         {
             // create pipeline barrier to safely release resources
@@ -416,8 +412,6 @@ VkFence vkrTexture2D_Upload(vkrTexture2D* tex, const void* data, i32 bytes)
     vkrBuffer_Release(&stagebuf, fence);
 
     tex->image.layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-
-    vkrTexTable_WriteSlot(&g_vkr.texTable, tex->slot, tex->sampler, tex->view, tex->image.layout);
 
     return fence;
 }

--- a/src/shaders/DepthOnly.hlsl
+++ b/src/shaders/DepthOnly.hlsl
@@ -1,7 +1,7 @@
 
 struct VSInput
 {
-    float4 positionOS : POSITION;
+    float4 positionWS : POSITION;
 };
 
 struct PSInput
@@ -12,13 +12,13 @@ struct PSInput
 [[vk::push_constant]]
 cbuffer push_constants
 {
-    float4x4 localToClip;
+    float4x4 worldToClip;
 };
 
 PSInput VSMain(VSInput input)
 {
     PSInput output;
-    output.positionCS = mul(localToClip, float4(input.positionOS.xyz, 1.0));
+    output.positionCS = mul(worldToClip, float4(input.positionWS.xyz, 1.0));
     return output;
 }
 

--- a/src/shaders/brush.hlsl
+++ b/src/shaders/brush.hlsl
@@ -79,7 +79,7 @@ PSOutput PSMain(PSInput input)
     float occlusion = rome.y;
     float metallic = rome.z;
     float emission = rome.w;
-    float3 light = 0.5 * albedo;
+    float3 light = 0.001 * albedo;
     {
         float3 emissive = UnpackEmission(albedo, emission);
         light += emissive;
@@ -92,12 +92,12 @@ PSOutput PSMain(PSInput input)
         //light += direct;
     }
     {
-        //float2 uv1 = input.uv01.zw;
-        //uint lmIndex = GetLightmapIndex(cameraData.lmBegin, li);
-        //float3 R = reflect(-V, N);
-        //GISample gi = SampleLightmap(lmIndex, uv1, input.TBN, N, R);
-        //float3 indirect = IndirectBRDF(V, N, gi.diffuse, gi.specular, albedo, roughness, metallic, occlusion);
-        //light += indirect;
+        float2 uv1 = input.uv01.zw;
+        uint lmIndex = GetLightmapIndex(cameraData.lmBegin, li);
+        float3 R = reflect(-V, N);
+        GISample gi = SampleLightmap(lmIndex, uv1, input.TBN, N, R);
+        float3 indirect = IndirectBRDF(V, N, gi.diffuse, gi.specular, albedo, roughness, metallic, occlusion);
+        light += indirect;
     }
 
     PSOutput output;

--- a/src/ui/cimgui.h
+++ b/src/ui/cimgui.h
@@ -61,92 +61,128 @@ typedef struct ImDrawData ImDrawData;
 typedef struct ImDrawCmd ImDrawCmd;
 typedef struct ImDrawChannel ImDrawChannel;
 
-typedef signed int ImTextureID;
-typedef unsigned int ImGuiID;
-typedef unsigned short ImWchar;
-typedef int ImGuiCol;
-typedef int ImGuiCond;
-typedef int ImGuiDataType;
-typedef int ImGuiDir;
-typedef int ImGuiKey;
-typedef int ImGuiNavInput;
-typedef int ImGuiMouseButton;
-typedef int ImGuiMouseCursor;
-typedef int ImGuiStyleVar;
-typedef int ImDrawCornerFlags;
-typedef int ImDrawListFlags;
-typedef int ImFontAtlasFlags;
-typedef int ImGuiBackendFlags;
-typedef int ImGuiColorEditFlags;
-typedef int ImGuiConfigFlags;
-typedef int ImGuiComboFlags;
-typedef int ImGuiDragDropFlags;
-typedef int ImGuiFocusedFlags;
-typedef int ImGuiHoveredFlags;
-typedef int ImGuiInputTextFlags;
-typedef int ImGuiSelectableFlags;
-typedef int ImGuiTabBarFlags;
-typedef int ImGuiTabItemFlags;
-typedef int ImGuiTreeNodeFlags;
-typedef int ImGuiWindowFlags;
-typedef int (*ImGuiInputTextCallback)(struct ImGuiInputTextCallbackData *data);
+typedef u32 ImTextureID;
+typedef u16 ImDrawIdx;
+typedef u32 ImGuiID;
+typedef u16 ImWchar;
+typedef i32 ImGuiCol;
+typedef i32 ImGuiCond;
+typedef i32 ImGuiDataType;
+typedef i32 ImGuiDir;
+typedef i32 ImGuiKey;
+typedef i32 ImGuiNavInput;
+typedef i32 ImGuiMouseButton;
+typedef i32 ImGuiMouseCursor;
+typedef i32 ImGuiStyleVar;
+typedef i32 ImDrawCornerFlags;
+typedef i32 ImDrawListFlags;
+typedef i32 ImFontAtlasFlags;
+typedef i32 ImGuiBackendFlags;
+typedef i32 ImGuiColorEditFlags;
+typedef i32 ImGuiConfigFlags;
+typedef i32 ImGuiComboFlags;
+typedef i32 ImGuiDragDropFlags;
+typedef i32 ImGuiFocusedFlags;
+typedef i32 ImGuiHoveredFlags;
+typedef i32 ImGuiInputTextFlags;
+typedef i32 ImGuiSelectableFlags;
+typedef i32 ImGuiTabBarFlags;
+typedef i32 ImGuiTabItemFlags;
+typedef i32 ImGuiTreeNodeFlags;
+typedef i32 ImGuiWindowFlags;
+typedef i32(*ImGuiInputTextCallback)(struct ImGuiInputTextCallbackData *data);
 typedef void (*ImGuiSizeCallback)(struct ImGuiSizeCallbackData* data);
 typedef void (*ImDrawCallback)(const struct ImDrawList* parent_list, const struct ImDrawCmd* cmd);
-typedef unsigned short ImDrawIdx;
 
 typedef struct ImVector
-{int Size;int Capacity;void* Data;} ImVector;
+{
+    i32 Size; i32 Capacity; void* Data;
+} ImVector;
 
 typedef struct ImVector_float
-{int Size;int Capacity;float* Data;} ImVector_float;
+{
+    i32 Size; i32 Capacity; float* Data;
+} ImVector_float;
 
 typedef struct ImVector_ImWchar
-{int Size;int Capacity;ImWchar* Data;} ImVector_ImWchar;
+{
+    i32 Size; i32 Capacity; ImWchar* Data;
+} ImVector_ImWchar;
 
 typedef struct ImVector_ImDrawVert
-{int Size;int Capacity; struct ImDrawVert* Data;} ImVector_ImDrawVert;
+{
+    i32 Size; i32 Capacity; struct ImDrawVert* Data;
+} ImVector_ImDrawVert;
 
 typedef struct ImVector_ImFontGlyph
-{int Size;int Capacity; struct ImFontGlyph* Data;} ImVector_ImFontGlyph;
+{
+    i32 Size; i32 Capacity; struct ImFontGlyph* Data;
+} ImVector_ImFontGlyph;
 
 typedef struct ImVector_ImGuiTextRange
-{int Size;int Capacity; struct ImGuiTextRange* Data;} ImVector_ImGuiTextRange;
+{
+    i32 Size; i32 Capacity; struct ImGuiTextRange* Data;
+} ImVector_ImGuiTextRange;
 
 typedef struct ImVector_ImGuiStoragePair
-{int Size;int Capacity; struct ImGuiStoragePair* Data;} ImVector_ImGuiStoragePair;
+{
+    i32 Size; i32 Capacity; struct ImGuiStoragePair* Data;
+} ImVector_ImGuiStoragePair;
 
 typedef struct ImVector_ImDrawChannel
-{int Size;int Capacity; struct ImDrawChannel* Data;} ImVector_ImDrawChannel;
+{
+    i32 Size; i32 Capacity; struct ImDrawChannel* Data;
+} ImVector_ImDrawChannel;
 
 typedef struct ImVector_char
-{int Size;int Capacity;char* Data;} ImVector_char;
+{
+    i32 Size; i32 Capacity; char* Data;
+} ImVector_char;
 
 typedef struct ImVector_ImU32
-{int Size;int Capacity;ImU32* Data;} ImVector_ImU32;
+{
+    i32 Size; i32 Capacity; ImU32* Data;
+} ImVector_ImU32;
 
 typedef struct ImVector_ImFontAtlasCustomRect
-{int Size;int Capacity; struct ImFontAtlasCustomRect* Data;} ImVector_ImFontAtlasCustomRect;
+{
+    i32 Size; i32 Capacity; struct ImFontAtlasCustomRect* Data;
+} ImVector_ImFontAtlasCustomRect;
 
 typedef struct ImVector_ImTextureID
-{int Size;int Capacity;ImTextureID* Data;} ImVector_ImTextureID;
+{
+    i32 Size; i32 Capacity; ImTextureID* Data;
+} ImVector_ImTextureID;
 
 typedef struct ImVector_ImFontConfig
-{int Size;int Capacity; struct ImFontConfig* Data;} ImVector_ImFontConfig;
+{
+    i32 Size; i32 Capacity; struct ImFontConfig* Data;
+} ImVector_ImFontConfig;
 
 typedef struct ImVector_ImFontPtr
-{int Size;int Capacity; struct ImFont** Data;} ImVector_ImFontPtr;
+{
+    i32 Size; i32 Capacity; struct ImFont** Data;
+} ImVector_ImFontPtr;
 
 typedef struct ImVector_ImDrawCmd
-{int Size;int Capacity; struct ImDrawCmd* Data;} ImVector_ImDrawCmd;
+{
+    i32 Size; i32 Capacity; struct ImDrawCmd* Data;
+} ImVector_ImDrawCmd;
 
 typedef struct ImVector_ImVec4
-{int Size;int Capacity;ImVec4* Data;} ImVector_ImVec4;
+{
+    i32 Size; i32 Capacity; ImVec4* Data;
+} ImVector_ImVec4;
 
 typedef struct ImVector_ImDrawIdx
-{int Size;int Capacity;ImDrawIdx* Data;} ImVector_ImDrawIdx;
+{
+    i32 Size; i32 Capacity; ImDrawIdx* Data;
+} ImVector_ImDrawIdx;
 
 typedef struct ImVector_ImVec2
-{int Size;int Capacity;ImVec2* Data;} ImVector_ImVec2;
+{
+    i32 Size; i32 Capacity; ImVec2* Data;
+} ImVector_ImVec2;
 
 typedef enum {
     ImGuiWindowFlags_None = 0,


### PR DESCRIPTION
Currently just culls entire drawables on main cpu thread.
Tried multithreading, but was a tiny bit slower.
Eventually want to do per-triangle culling in a compute shader.
Quake maps are very low poly so its not really needed. 