### PR TITLE
[Minor] lightmap naming

### DIFF
--- a/src/rendering/lightmap.c
+++ b/src/rendering/lightmap.c
@@ -1609,7 +1609,7 @@ static cmdstat_t CmdPrintLm(i32 argc, const char** argv)
 {
     cmdstat_t status = cmdstat_ok;
     char filename[PIM_PATH] = { 0 };
-    const char* prefix = "lightmap";
+    const char* prefix = "lightmap_color";
     LmChannel channel = LmChannel_Color;
     R8G8B8A8_t* dstBuffer = NULL;
     const LmPack* pack = LmPack_Get();


### PR DESCRIPTION
Very minor--when 'color' command isn't specified, lightmaps saved to an inconsistent filename

Without 'color' command they are saved to `lightmap` even though they are the color lightmap. When 'color' is specified they are saved to lightmap_color.