### PR TITLE
Fix bug in hash set removal

### DIFF
--- a/src/containers/hash_set.c
+++ b/src/containers/hash_set.c
@@ -153,7 +153,7 @@ bool HashSet_Rm(HashSet* set, const void* key, u32 keySize)
     const i32 i = hashset_find(set, key, keySize);
     if (i != -1)
     {
-        set->hashes[i] = hashutil_tomb_mask;
+        set->hashes[i] |= hashutil_tomb_mask;
         u8* keys = set->keys;
         memset(keys + keySize * i, 0, keySize);
         --(set->count);


### PR DESCRIPTION
Setting the tombstone was mistakenly marking the hash as empty, so if there were later entries they weren't being found.

Seems the hashset isn't used anywhere yet, but I was using it for my lua stuff and discovered this :)