### PR TITLE
Fix indexing typo and create stress test

### DIFF
--- a/script/tests/vector_test.lua
+++ b/script/tests/vector_test.lua
@@ -1,0 +1,11 @@
+local Cvar = require("cvar")
+
+local vector_test = {}
+
+function vector_test:update()
+  for i=1, 10000 do
+    local sun_vector = Cvar.get("r_sun_col")
+  end
+end
+
+Game.start_update(vector_test);

--- a/src/scriptsys/scr_cvar.c
+++ b/src/scriptsys/scr_cvar.c
@@ -11,13 +11,13 @@ static void VEC_CALL scr_push_vec(lua_State* L, float4 vec)
 {
 	lua_createtable(L, 4, 0);
 	lua_pushnumber(L, vec.x);
-	lua_setfield(L, -1, "x");
+	lua_setfield(L, -2, "x");
 	lua_pushnumber(L, vec.y);
-	lua_setfield(L, -1, "y");
+	lua_setfield(L, -2, "y");
 	lua_pushnumber(L, vec.z);
-	lua_setfield(L, -1, "z");
+	lua_setfield(L, -2, "z");
 	lua_pushnumber(L, vec.w);
-	lua_setfield(L, -1, "w");
+	lua_setfield(L, -2, "w");
 }
 
 static lua_Number scr_checknumberfield(lua_State* L, i32 pos, const char* field)


### PR DESCRIPTION
Currently steady 40ms for 10000 cvar queries and transferring a vec4.